### PR TITLE
feat(ui): rename Run button + stale-graph banner (#21, #22)

### DIFF
--- a/app/src/components/EditorArea.tsx
+++ b/app/src/components/EditorArea.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useCallback, useRef, useMemo, useState } from 'react';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { Loader2, AlertCircle, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
-import { SqlView, useLineageState } from '@pondpilot/flowscope-react';
+import {
+  SqlView,
+  computeStalePaths,
+  useLineageActions,
+  useLineageState,
+} from '@pondpilot/flowscope-react';
 import { cn } from '@/lib/utils';
 import { useProject } from '@/lib/project-store';
 import { useThemeStore, resolveTheme } from '@/lib/theme-store';
@@ -58,7 +63,9 @@ export function EditorArea({
   const previousSchema = useRef<string | null>(null);
   const previousHideCTEs = useRef<boolean | null>(null);
 
-  const { hideCTEs, highlightedSpan, result } = useLineageState();
+  const { hideCTEs, highlightedSpan, result, analyzedContentByPath, stalePaths } =
+    useLineageState();
+  const { setStalePaths } = useLineageActions();
 
   // SQL view mode toggle: 'template' shows original templated SQL, 'resolved' shows compiled SQL
   const [sqlViewMode, setSqlViewMode] = useState<SqlViewMode>('template');
@@ -105,6 +112,23 @@ export function EditorArea({
       });
     }
   }, [activeFile?.id]);
+
+  // Recompute stale paths whenever the snapshot or any live file content
+  // changes. `currentFiles` intentionally reads from `currentProject?.files`
+  // directly so editor keystrokes feed in without a debounce — staleness
+  // should flip the moment the buffer diverges.
+  const currentFiles = useMemo(
+    () =>
+      (currentProject?.files ?? [])
+        .filter((f) => f.name.endsWith('.sql'))
+        .map((f) => ({ path: f.path, content: f.content })),
+    [currentProject?.files]
+  );
+
+  useEffect(() => {
+    const next = computeStalePaths(analyzedContentByPath, currentFiles);
+    setStalePaths(next);
+  }, [analyzedContentByPath, currentFiles, setStalePaths]);
 
   // Auto-trigger re-analysis when schema or hideCTEs changes.
   // Consolidated into a single effect to prevent duplicate analyses when both change.
@@ -226,6 +250,8 @@ export function EditorArea({
 
   const allFileCount = currentProject.files.filter((f) => f.name.endsWith('.sql')).length;
   const selectedCount = currentProject.selectedFileIds?.length || 0;
+  const activePath = activeFile.path || activeFile.name;
+  const isActiveFileStale = stalePaths.has(activePath);
 
   return (
     <div className={cn('flex flex-col h-full bg-background', className)}>
@@ -244,6 +270,18 @@ export function EditorArea({
         showSqlViewToggle={showSqlViewToggle}
         hasResolvedSql={!!resolvedSql}
       />
+
+      {isActiveFileStale && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="stale-graph-banner"
+          className="flex items-center gap-2 px-3 py-1.5 text-xs border-b bg-amber-500/10 text-amber-900 dark:text-amber-100 border-amber-500/30"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          <span>Graph is out of sync with text &mdash; re-run analysis to enable navigation.</span>
+        </div>
+      )}
 
       <div
         ref={editorContainerRef}

--- a/app/src/components/EditorToolbar.tsx
+++ b/app/src/components/EditorToolbar.tsx
@@ -104,7 +104,7 @@ export function EditorToolbar({
             ) : (
               <Play className="h-3.5 w-3.5 fill-current" />
             )}
-            <span className="hidden sm:inline">Run</span>
+            <span className="hidden sm:inline">Lineage</span>
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -297,6 +297,13 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         // allowing UI interactions and worker callbacks to proceed without blocking
         startTransition(() => {
           actionsRef.current.setResult(cached.result);
+          // Cache hits imply the current file content already matches what
+          // was analyzed (cache key is content-derived), so seed the
+          // staleness snapshot from the live files used to build `context`.
+          actionsRef.current.setAnalyzedContent(
+            new Map(context.files.map((f) => [f.name, f.content]))
+          );
+          actionsRef.current.setStalePaths([]);
         });
         storeResult(activeProjectId, cached.result, hideCTEs);
         setMetrics(activeProjectId, {
@@ -467,6 +474,13 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
           // allowing UI interactions and worker callbacks to proceed without blocking
           startTransition(() => {
             actionsRef.current.setResult(analysisResponse.result);
+            // Snapshot the exact content that was just analyzed so the
+            // staleness gate (#22) has a baseline to diff future edits
+            // against. Keyed by the same path the analyzer keys statements by.
+            actionsRef.current.setAnalyzedContent(
+              new Map(context.files.map((f) => [f.name, f.content]))
+            );
+            actionsRef.current.setStalePaths([]);
           });
           if (activeProjectId) {
             storeResult(activeProjectId, analysisResponse.result, hideCTEs);

--- a/packages/react/src/components/OccurrenceCycler.tsx
+++ b/packages/react/src/components/OccurrenceCycler.tsx
@@ -2,7 +2,7 @@ import { type JSX, type MouseEvent } from 'react';
 
 import { useLineageActions, useLineageStore } from '../store';
 import { useColors } from '../hooks/useColors';
-import { findMergedNodeById } from '../utils/nodeOccurrences';
+import { findMergedNodeById, resolveNodeSourceName } from '../utils/nodeOccurrences';
 
 interface OccurrenceCyclerProps {
   /** The graph node id this cycler belongs to. */
@@ -25,6 +25,7 @@ export function OccurrenceCycler({ nodeId }: OccurrenceCyclerProps): JSX.Element
   const isSelected = useLineageStore((state) => state.selectedNodeId === nodeId);
   const focusedIndex = useLineageStore((state) => state.focusedOccurrenceIndex);
   const result = useLineageStore((state) => state.result);
+  const stalePaths = useLineageStore((state) => state.stalePaths);
   const colors = useColors();
 
   if (!isSelected || result === null) {
@@ -37,25 +38,37 @@ export function OccurrenceCycler({ nodeId }: OccurrenceCyclerProps): JSX.Element
     return null;
   }
 
+  // A node's name spans live inside the SQL of one `sourceName` file. If
+  // that file's live buffer has drifted from the analyzed snapshot, the
+  // recorded byte offsets no longer line up with the current text — cycling
+  // would jump to wrong positions, so we disable (but still show the
+  // counter so the count stays visible as context).
+  const statementById = new Map(result.statements.map((s) => [s.statementIndex, s]));
+  const nodeSourceName = resolveNodeSourceName(node!, statementById);
+  const isStale = nodeSourceName ? stalePaths.has(nodeSourceName) : false;
+
   const handlePrev = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
+    if (isStale) return;
     cycleOccurrence('prev');
   };
   const handleNext = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
+    if (isStale) return;
     cycleOccurrence('next');
   };
 
   const buttonStyle = {
     background: 'none',
     border: 'none',
-    cursor: 'pointer',
+    cursor: isStale ? 'not-allowed' : 'pointer',
     padding: '2px 4px',
     color: colors.nodes.table.textSecondary,
     display: 'inline-flex',
     alignItems: 'center',
     borderRadius: 3,
     lineHeight: 1,
+    opacity: isStale ? 0.4 : 1,
   } as const;
 
   // 1-based for users; 0-based for state.
@@ -75,7 +88,11 @@ export function OccurrenceCycler({ nodeId }: OccurrenceCyclerProps): JSX.Element
         fontWeight: 600,
         fontVariantNumeric: 'tabular-nums',
       }}
-      title={`Cycle through ${total} occurrences of this name in the SQL (n / Shift+n)`}
+      title={
+        isStale
+          ? 'SQL has changed since analysis — re-run analysis to navigate occurrences'
+          : `Cycle through ${total} occurrences of this name in the SQL (n / Shift+n)`
+      }
       aria-label={`Occurrence ${displayIndex} of ${total}`}
       role="status"
       aria-live="polite"
@@ -86,13 +103,22 @@ export function OccurrenceCycler({ nodeId }: OccurrenceCyclerProps): JSX.Element
         onClick={handlePrev}
         style={buttonStyle}
         aria-label="Previous occurrence"
+        aria-disabled={isStale || undefined}
+        disabled={isStale}
       >
         ◀
       </button>
       <span style={{ minWidth: 22, textAlign: 'center' }}>
         {displayIndex}/{total}
       </span>
-      <button type="button" onClick={handleNext} style={buttonStyle} aria-label="Next occurrence">
+      <button
+        type="button"
+        onClick={handleNext}
+        style={buttonStyle}
+        aria-label="Next occurrence"
+        aria-disabled={isStale || undefined}
+        disabled={isStale}
+      >
         ▶
       </button>
     </span>

--- a/packages/react/src/components/SqlView.tsx
+++ b/packages/react/src/components/SqlView.tsx
@@ -76,7 +76,13 @@ export function SqlView({
   const { state, actions } = useLineage();
   const revealNodeInGraph = useLineageStore((store) => store.revealNodeInGraph);
   const visibleGraphNodeIds = useLineageStore((store) => store.visibleGraphNodeIds);
+  const stalePaths = useLineageStore((store) => store.stalePaths);
   const isControlled = value !== undefined;
+  // When the caller declares which analyzed source this editor represents,
+  // treat the reveal action as stale if that path has diverged from the
+  // analyzed snapshot. Offsets from the stale span index would land in the
+  // wrong place, so we'd rather hide the affordance than navigate wrong.
+  const isCurrentSourceStale = Boolean(analyzedSourceName && stalePaths.has(analyzedSourceName));
 
   // Warn in dev mode if highlightedSpan is passed without value (it will be ignored)
   if (process.env.NODE_ENV !== 'production' && !isControlled && highlightedSpanProp !== undefined) {
@@ -294,7 +300,7 @@ export function SqlView({
     }
   }, [highlightedSpan, issueHighlights, isControlled, sqlText]);
 
-  const canReveal = revealCandidateId !== null;
+  const canReveal = revealCandidateId !== null && !isCurrentSourceStale;
 
   return (
     <div className={`flowscope-sql-view ${className || ''}`} onMouseDown={handleEditorMouseDown}>

--- a/packages/react/src/hooks/useOccurrenceShortcuts.ts
+++ b/packages/react/src/hooks/useOccurrenceShortcuts.ts
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-import { useLineageActions } from '../store';
+import { useLineageActions, useLineageStore } from '../store';
+import { findMergedNodeById, resolveNodeSourceName } from '../utils/nodeOccurrences';
 
 /**
  * Global keyboard shortcuts for cycling through the focused node's
@@ -14,12 +15,34 @@ import { useLineageActions } from '../store';
  */
 export function useOccurrenceShortcuts(): void {
   const { cycleOccurrence } = useLineageActions();
+  // Mirror the store slices we need into refs so the keydown handler can
+  // read them synchronously without re-binding on every change.
+  const selectedNodeId = useLineageStore((state) => state.selectedNodeId);
+  const result = useLineageStore((state) => state.result);
+  const stalePaths = useLineageStore((state) => state.stalePaths);
+  const staleStateRef = useRef({ selectedNodeId, result, stalePaths });
+  staleStateRef.current = { selectedNodeId, result, stalePaths };
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if (event.key !== 'n' && event.key !== 'N') return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (isTypingTarget(event.target)) return;
+
+      // Suppress when the selected node's file is stale — its name spans
+      // no longer match the editor text, so cycling would jump to wrong
+      // positions.
+      const snapshot = staleStateRef.current;
+      if (snapshot.selectedNodeId && snapshot.result) {
+        const node = findMergedNodeById(snapshot.result, snapshot.selectedNodeId);
+        if (node) {
+          const statementById = new Map(
+            snapshot.result.statements.map((s) => [s.statementIndex, s])
+          );
+          const sourceName = resolveNodeSourceName(node, statementById);
+          if (sourceName && snapshot.stalePaths.has(sourceName)) return;
+        }
+      }
 
       event.preventDefault();
       cycleOccurrence(event.shiftKey ? 'prev' : 'next');

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -103,3 +103,6 @@ export {
 } from './utils/graphTraversal';
 
 export type { ApplyTableFilterResult } from './utils/graphTraversal';
+
+// Stale-graph tracking
+export { computeStalePaths } from './utils/staleContent';

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -193,6 +193,19 @@ export interface LineageState {
   tableFilter: TableFilter;
   isLayouting: boolean;
   isBuilding: boolean;
+  /**
+   * Snapshot of the SQL text each path held when the most recent analysis
+   * ran, keyed by the same `sourceName` the analyzer uses. Consumers diff
+   * this against live file content to decide whether the graph's spans are
+   * still aligned with the editor (#22). `null` before any analysis has run.
+   */
+  analyzedContentByPath: ReadonlyMap<string, string> | null;
+  /**
+   * Paths whose current content has diverged from `analyzedContentByPath`.
+   * Populated by the app layer (which owns the live file content) via
+   * `setStalePaths`. Nav affordances gated by membership in this set (#22).
+   */
+  stalePaths: ReadonlySet<string>;
 
   // Actions
   setResult: (result: AnalyzeResult | null) => void;
@@ -245,6 +258,20 @@ export interface LineageState {
   clearTableFilter: () => void;
   setIsLayouting: (isLayouting: boolean) => void;
   setIsBuilding: (isBuilding: boolean) => void;
+  /**
+   * Replace the analyzed-content snapshot. Called after a successful
+   * analysis run with a path→content map covering every file that went
+   * into the analyzer. Pass `null` to clear (e.g. when the result itself
+   * is cleared).
+   */
+  setAnalyzedContent: (map: ReadonlyMap<string, string> | null) => void;
+  /**
+   * Replace the set of paths whose live content diverges from the analyzed
+   * snapshot. Computed by the app and pushed here so that components
+   * without access to the project store (the graph's OccurrenceCycler,
+   * useOccurrenceShortcuts) can gate on staleness uniformly.
+   */
+  setStalePaths: (paths: Iterable<string>) => void;
 }
 
 /**
@@ -299,6 +326,8 @@ export function createLineageStore(
     tableFilter: { selectedTableLabels: new Set(), direction: 'both' },
     isLayouting: false,
     isBuilding: false,
+    analyzedContentByPath: null,
+    stalePaths: new Set(),
     ...initialState,
 
     // Actions
@@ -320,6 +349,10 @@ export function createLineageStore(
           collapsedNodeIds: new Set(),
           expandedTableIds: new Set(),
           selectedStatementIndex: statementCount === 0 ? 0 : newSelectedStatementIndex,
+          // Clearing the result invalidates any staleness derived from it.
+          // A successful re-analysis will immediately refill these via
+          // setAnalyzedContent / setStalePaths in the app layer.
+          ...(result === null ? { analyzedContentByPath: null, stalePaths: new Set() } : {}),
         };
       }),
 
@@ -509,6 +542,22 @@ export function createLineageStore(
     setIsLayouting: (isLayouting) => set({ isLayouting }),
 
     setIsBuilding: (isBuilding) => set({ isBuilding }),
+
+    setAnalyzedContent: (map) => set({ analyzedContentByPath: map }),
+
+    setStalePaths: (paths) =>
+      set((state) => {
+        const next = new Set(paths);
+        if (next.size !== state.stalePaths.size) {
+          return { stalePaths: next };
+        }
+        for (const path of next) {
+          if (!state.stalePaths.has(path)) {
+            return { stalePaths: next };
+          }
+        }
+        return state;
+      }),
   }));
 }
 
@@ -570,6 +619,8 @@ export function useLineage() {
       tableFilter: store.tableFilter,
       isLayouting: store.isLayouting,
       isBuilding: store.isBuilding,
+      analyzedContentByPath: store.analyzedContentByPath,
+      stalePaths: store.stalePaths,
     },
     actions: {
       setResult: store.setResult,
@@ -601,6 +652,8 @@ export function useLineage() {
       clearTableFilter: store.clearTableFilter,
       setIsLayouting: store.setIsLayouting,
       setIsBuilding: store.setIsBuilding,
+      setAnalyzedContent: store.setAnalyzedContent,
+      setStalePaths: store.setStalePaths,
     },
   };
 }
@@ -635,6 +688,8 @@ export function useLineageState() {
   const tableFilter = useLineageStore((state) => state.tableFilter);
   const isLayouting = useLineageStore((state) => state.isLayouting);
   const isBuilding = useLineageStore((state) => state.isBuilding);
+  const analyzedContentByPath = useLineageStore((state) => state.analyzedContentByPath);
+  const stalePaths = useLineageStore((state) => state.stalePaths);
 
   return {
     result,
@@ -661,6 +716,8 @@ export function useLineageState() {
     tableFilter,
     isLayouting,
     isBuilding,
+    analyzedContentByPath,
+    stalePaths,
   };
 }
 
@@ -697,6 +754,8 @@ export function useLineageActions() {
   const clearTableFilter = useLineageStore((state) => state.clearTableFilter);
   const setIsLayouting = useLineageStore((state) => state.setIsLayouting);
   const setIsBuilding = useLineageStore((state) => state.setIsBuilding);
+  const setAnalyzedContent = useLineageStore((state) => state.setAnalyzedContent);
+  const setStalePaths = useLineageStore((state) => state.setStalePaths);
 
   return {
     setResult,
@@ -728,5 +787,7 @@ export function useLineageActions() {
     clearTableFilter,
     setIsLayouting,
     setIsBuilding,
+    setAnalyzedContent,
+    setStalePaths,
   };
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -139,6 +139,19 @@ export interface LineageState {
   revealRequest: { nodeId: string; nonce: number; suppressNavigation: boolean } | null;
   /** Table filter configuration */
   tableFilter: TableFilter;
+  /**
+   * Snapshot of the SQL text each path held when the most recent analysis
+   * ran, keyed by the analyzer's `sourceName`. `null` before any analysis
+   * has run. Consumers diff this against live file content to gate graph↔
+   * text navigation on staleness (#22).
+   */
+  analyzedContentByPath: ReadonlyMap<string, string> | null;
+  /**
+   * Paths whose live content has diverged from `analyzedContentByPath`.
+   * Written by the app layer; read by components that need to disable nav
+   * (OccurrenceCycler, useOccurrenceShortcuts, SqlView reveal button).
+   */
+  stalePaths: ReadonlySet<string>;
 }
 
 /**
@@ -204,6 +217,10 @@ export interface LineageActions {
   setTableFilterDirection: (direction: TableFilterDirection) => void;
   /** Clear the table filter */
   clearTableFilter: () => void;
+  /** Replace the analyzed-content snapshot (or clear with null). */
+  setAnalyzedContent: (map: ReadonlyMap<string, string> | null) => void;
+  /** Replace the set of paths whose content has diverged from the snapshot. */
+  setStalePaths: (paths: Iterable<string>) => void;
 }
 
 /**

--- a/packages/react/src/utils/staleContent.ts
+++ b/packages/react/src/utils/staleContent.ts
@@ -1,0 +1,31 @@
+/**
+ * Diff a snapshot of analyzed file content against the current project
+ * files to determine which paths' graph spans are out of sync.
+ *
+ * Consumed by the stale-graph banner and nav-affordance gates (#22).
+ *
+ * A path is considered present in the snapshot only if it had an entry at
+ * analysis time (i.e. it was actually analyzed). New files the user added
+ * after analysis are not stale — they simply aren't in the graph yet. A
+ * path that was analyzed but is now missing from `currentFiles` is stale
+ * (the removal shifts nothing, but treating it as stale keeps consumers
+ * from navigating to content that no longer exists).
+ */
+export function computeStalePaths(
+  analyzedContentByPath: ReadonlyMap<string, string> | null,
+  currentFiles: ReadonlyArray<{ path: string; content: string }>
+): Set<string> {
+  const stale = new Set<string>();
+  if (!analyzedContentByPath) return stale;
+
+  const currentByPath = new Map(currentFiles.map((f) => [f.path, f.content]));
+
+  for (const [path, snapshot] of analyzedContentByPath) {
+    const current = currentByPath.get(path);
+    if (current !== snapshot) {
+      stale.add(path);
+    }
+  }
+
+  return stale;
+}

--- a/packages/react/tests/staleContent.test.ts
+++ b/packages/react/tests/staleContent.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import { computeStalePaths } from '../src/utils/staleContent';
+
+describe('computeStalePaths', () => {
+  it('returns an empty set when no analysis snapshot exists', () => {
+    const stale = computeStalePaths(null, [{ path: 'a.sql', content: 'SELECT 1' }]);
+    expect(stale.size).toBe(0);
+  });
+
+  it('returns an empty set when every analyzed path matches current content', () => {
+    const snapshot = new Map([
+      ['a.sql', 'SELECT 1'],
+      ['b.sql', 'SELECT 2'],
+    ]);
+    const stale = computeStalePaths(snapshot, [
+      { path: 'a.sql', content: 'SELECT 1' },
+      { path: 'b.sql', content: 'SELECT 2' },
+    ]);
+    expect(stale.size).toBe(0);
+  });
+
+  it('flags a path whose content has diverged (edit)', () => {
+    const snapshot = new Map([['a.sql', 'SELECT 1']]);
+    const stale = computeStalePaths(snapshot, [{ path: 'a.sql', content: 'SELECT 2' }]);
+    expect(stale.has('a.sql')).toBe(true);
+    expect(stale.size).toBe(1);
+  });
+
+  it('clears a path after an edit is undone (content matches snapshot again)', () => {
+    const snapshot = new Map([['a.sql', 'SELECT 1']]);
+    // Edited: stale.
+    expect(computeStalePaths(snapshot, [{ path: 'a.sql', content: 'SELECT 2' }]).has('a.sql')).toBe(
+      true
+    );
+    // Undone back to the original: not stale.
+    expect(computeStalePaths(snapshot, [{ path: 'a.sql', content: 'SELECT 1' }]).has('a.sql')).toBe(
+      false
+    );
+  });
+
+  it('flags a path that was analyzed but is now missing from the project (deleted/renamed)', () => {
+    const snapshot = new Map([['a.sql', 'SELECT 1']]);
+    const stale = computeStalePaths(snapshot, []);
+    expect(stale.has('a.sql')).toBe(true);
+  });
+
+  it('ignores files added after analysis — they are not stale, just not in the graph yet', () => {
+    const snapshot = new Map([['a.sql', 'SELECT 1']]);
+    const stale = computeStalePaths(snapshot, [
+      { path: 'a.sql', content: 'SELECT 1' },
+      { path: 'newly_added.sql', content: 'SELECT 42' },
+    ]);
+    expect(stale.size).toBe(0);
+  });
+
+  it('is sensitive to trailing-newline edits (strict equality)', () => {
+    const snapshot = new Map([['a.sql', 'SELECT 1']]);
+    const stale = computeStalePaths(snapshot, [{ path: 'a.sql', content: 'SELECT 1\n' }]);
+    expect(stale.has('a.sql')).toBe(true);
+  });
+});

--- a/packages/react/tests/stalePaths.test.ts
+++ b/packages/react/tests/stalePaths.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { StoreApi } from 'zustand/vanilla';
+import type { AnalyzeResult } from '@pondpilot/flowscope-core';
+
+import { createLineageStore, type LineageState } from '../src/store';
+
+function buildResult(): AnalyzeResult {
+  return {
+    statements: [
+      {
+        statementIndex: 0,
+        statementType: 'SELECT',
+        sourceName: 'models/users.sql',
+        joinCount: 0,
+        complexityScore: 1,
+      },
+    ],
+    nodes: [
+      {
+        id: 'table:users',
+        type: 'table',
+        label: 'users',
+        statementIds: [0],
+        span: { start: 14, end: 19 },
+        nameSpans: [{ start: 14, end: 19 }],
+      },
+    ],
+    edges: [],
+    issues: [],
+    summary: {
+      statementCount: 1,
+      tableCount: 1,
+      columnCount: 0,
+      joinCount: 0,
+      complexityScore: 1,
+      issueCount: { errors: 0, warnings: 0, infos: 0 },
+      hasErrors: false,
+    },
+  };
+}
+
+describe('stale-graph store fields', () => {
+  let store: StoreApi<LineageState>;
+
+  beforeEach(() => {
+    store = createLineageStore();
+  });
+
+  it('starts with null analyzed snapshot and an empty stale set', () => {
+    const state = store.getState();
+    expect(state.analyzedContentByPath).toBeNull();
+    expect(state.stalePaths.size).toBe(0);
+  });
+
+  it('setAnalyzedContent stores the snapshot map', () => {
+    const snapshot = new Map([['models/users.sql', 'SELECT * FROM users']]);
+    store.getState().setAnalyzedContent(snapshot);
+    expect(store.getState().analyzedContentByPath).toBe(snapshot);
+  });
+
+  it('setStalePaths replaces the set and is a no-op when set membership is unchanged', () => {
+    store.getState().setStalePaths(['a.sql', 'b.sql']);
+    const first = store.getState().stalePaths;
+    expect(first.has('a.sql')).toBe(true);
+    expect(first.has('b.sql')).toBe(true);
+
+    // Same membership → reference should not change (avoids extra re-renders).
+    store.getState().setStalePaths(['a.sql', 'b.sql']);
+    expect(store.getState().stalePaths).toBe(first);
+
+    // Different membership → reference changes.
+    store.getState().setStalePaths(['a.sql']);
+    expect(store.getState().stalePaths).not.toBe(first);
+    expect(store.getState().stalePaths.has('b.sql')).toBe(false);
+  });
+
+  it('clears both snapshot and stale set when the result is cleared', () => {
+    store.getState().setResult(buildResult());
+    store.getState().setAnalyzedContent(new Map([['a.sql', 'SELECT 1']]));
+    store.getState().setStalePaths(['a.sql']);
+
+    store.getState().setResult(null);
+
+    const state = store.getState();
+    expect(state.analyzedContentByPath).toBeNull();
+    expect(state.stalePaths.size).toBe(0);
+  });
+
+  it('preserves the snapshot across a successful re-analyze (non-null setResult)', () => {
+    const snapshot = new Map([['a.sql', 'SELECT 1']]);
+    store.getState().setResult(buildResult());
+    store.getState().setAnalyzedContent(snapshot);
+
+    // A re-analysis calls setResult(result) first; the app then pushes a
+    // fresh snapshot. In between, we must not wipe the prior snapshot —
+    // otherwise the nav would blink stale→fresh for a frame.
+    store.getState().setResult(buildResult());
+    expect(store.getState().analyzedContentByPath).toBe(snapshot);
+  });
+});


### PR DESCRIPTION
Closes #21, closes #22.

## Summary
- Rename primary action button from **Run** to **Lineage** (#21).
- Track per-file analyzed-SQL snapshot and show a non-blocking banner + disable nav affordances whenever the editor diverges from the analyzed text (#22).

## Why
After #23/#24 shipped bidirectional text↔graph navigation, any post-analysis edit silently invalidates the byte-offset spans the navigation relies on — clicking an occurrence arrow or "Reveal in lineage" would jump to the wrong place. The banner + gates make that invariant visible and the nav safe.

## Design
- `LineageState` gains `analyzedContentByPath: ReadonlyMap<string,string> | null` (snapshot taken at analyze time) and `stalePaths: ReadonlySet<string>` (paths whose live content diverges). Both cleared on `setResult(null)`; snapshot preserved across successful re-analyze to avoid a stale→fresh flicker.
- App owns the ground truth (project files); `EditorArea` runs `computeStalePaths(snapshot, currentFiles)` on every content change and pushes the result via `setStalePaths`. `useAnalysis` seeds the snapshot on successful analyze and on IndexedDB cache-hit restore.
- Staleness comparator is strict equality — any byte-level edit flags the path. Cheap, honest, and matches the byte-offset semantics of the spans we're protecting.
- Nav gates live next to their affordances: `OccurrenceCycler` (disabled ◀/▶ with `aria-disabled`), `useOccurrenceShortcuts` (n/Shift+n short-circuit), `SqlView` ("Reveal in lineage" hidden).

## Scope notes
- Dropdown labels ("Run Configuration", "Run Active File Only", etc.) left untouched — they describe execution *modes*, not the primary action.
- No Playwright test (app has no test harness yet); covered via unit tests on the pure comparator and store behavior instead.

## Test plan
- [x] `yarn workspaces run typecheck` — all workspaces clean
- [x] `yarn workspaces run test` — 169 tests pass including 12 new ones (`staleContent.test.ts`, `stalePaths.test.ts`)
- [x] `yarn workspaces run lint` — clean
- [x] `yarn workspace @pondpilot/flowscope-app build` — builds
- [ ] Manual smoke: edit analyzed SQL → banner appears, cycler dims, reveal button hides
- [ ] Manual smoke: undo back to analyzed content → banner clears, nav re-enables
- [ ] Manual smoke: re-run analysis after edit → banner clears, nav re-enables