### PR TITLE
feat(graph): collapse/expand single-edge node pairs (#28)

### DIFF
--- a/packages/react/src/components/AnimatedEdge.tsx
+++ b/packages/react/src/components/AnimatedEdge.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type CSSProperties, type JSX } from 'react';
+import { useCallback, useMemo, type CSSProperties, type JSX, type MouseEvent } from 'react';
 import { BaseEdge, EdgeLabelRenderer, getBezierPath } from '@xyflow/react';
 import type { EdgeProps } from '@xyflow/react';
 import {
@@ -10,6 +10,7 @@ import {
 } from './ui/graph-tooltip';
 import { GRAPH_CONFIG, EDGE_STYLES, JOIN_TYPE_LABELS } from '../constants';
 import { useColors } from '../hooks/useColors';
+import { useLineageStore } from '../store';
 
 export type EdgeType = 'dataFlow' | 'derivation' | 'joinDependency' | 'aggregation';
 
@@ -112,9 +113,25 @@ export function AnimatedEdge({
   const edgeType = data?.type as EdgeType | string | undefined;
   const joinType = data?.joinType as string | undefined;
   const joinCondition = data?.joinCondition as string | undefined;
+  const chainCollapsible = data?.chainCollapsible as boolean | undefined;
+  const chainFolded = data?.chainFolded as boolean | undefined;
+  const chainFoldCount = data?.chainFoldCount as number | undefined;
+  const chainToggleNodeId = data?.chainToggleNodeId as string | undefined;
   const labelZIndex = isHighlighted
     ? GRAPH_CONFIG.HIGHLIGHTED_EDGE_Z_INDEX
     : GRAPH_CONFIG.EDGE_LABEL_BASE_Z_INDEX;
+
+  const toggleChainCollapse = useLineageStore((store) => store.toggleChainCollapse);
+  const handleChainToggle = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (chainToggleNodeId) {
+        toggleChainCollapse(chainToggleNodeId);
+      }
+    },
+    [chainToggleNodeId, toggleChainCollapse]
+  );
 
   const tooltipContent = useMemo(() => {
     let content = customTooltip || '';
@@ -237,6 +254,52 @@ export function AnimatedEdge({
         <g transform={`translate(${labelX}, ${labelY})`}>
           <title>{tooltipContent}</title>
         </g>
+      )}
+      {(chainFolded || chainCollapsible) && !expression && !joinType && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              pointerEvents: 'all',
+              zIndex: labelZIndex,
+            }}
+            className="nodrag nopan"
+          >
+            <button
+              type="button"
+              onClick={handleChainToggle}
+              aria-label={
+                chainFolded
+                  ? `Expand ${chainFoldCount ?? 1} collapsed node${(chainFoldCount ?? 1) === 1 ? '' : 's'}`
+                  : 'Collapse this chain into its parent'
+              }
+              title={
+                chainFolded
+                  ? `${chainFoldCount ?? 1} node${(chainFoldCount ?? 1) === 1 ? '' : 's'} folded — click to expand`
+                  : 'Collapse into parent'
+              }
+              style={{
+                cursor: 'pointer',
+                background: chainFolded ? colors.edges.dataFlow : colors.nodes.table.bg,
+                color: chainFolded ? colors.nodes.table.bg : colors.edges.dataFlow,
+                border: `1px solid ${colors.edges.dataFlow}`,
+                borderRadius: 10,
+                padding: '0 6px',
+                minHeight: 16,
+                fontSize: 10,
+                fontWeight: 700,
+                lineHeight: 1,
+                display: 'inline-flex',
+                alignItems: 'center',
+                boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {chainFolded ? `+${chainFoldCount ?? 1}` : '−'}
+            </button>
+          </div>
+        </EdgeLabelRenderer>
       )}
     </>
   );

--- a/packages/react/src/components/GraphView.tsx
+++ b/packages/react/src/components/GraphView.tsx
@@ -380,6 +380,7 @@ export function GraphView({
     showColumnEdges,
     showScriptTables,
     expandedTableIds,
+    collapsedChainNodeIds,
     tableFilter,
     focusedOccurrenceIndex,
   } = state;
@@ -492,6 +493,7 @@ export function GraphView({
               searchTerm: effectiveSearchTerm,
               collapsedNodeIds,
               expandedTableIds,
+              collapsedChainNodeIds,
               resolvedSchema: analysisResult.resolvedSchema,
               defaultCollapsed,
               showColumnEdges,
@@ -555,6 +557,7 @@ export function GraphView({
     showColumnEdges,
     showScriptTables,
     expandedTableIds,
+    collapsedChainNodeIds,
     setIsBuilding,
   ]);
 

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -206,6 +206,14 @@ export interface LineageState {
    * `setStalePaths`. Nav affordances gated by membership in this set (#22).
    */
   stalePaths: ReadonlySet<string>;
+  /**
+   * Node ids the user has chosen to fold into their single parent via the
+   * edge-mounted chain-collapse toggle (#28). A selection is only honored
+   * if the node is still chain-collapsible in the current graph (see
+   * `isChainCollapsible`), so stale selections across re-analysis are
+   * ignored rather than throwing errors.
+   */
+  collapsedChainNodeIds: ReadonlySet<string>;
 
   // Actions
   setResult: (result: AnalyzeResult | null) => void;
@@ -272,6 +280,13 @@ export interface LineageState {
    * useOccurrenceShortcuts) can gate on staleness uniformly.
    */
   setStalePaths: (paths: Iterable<string>) => void;
+  /**
+   * Flip a node's chain-collapse selection. Adding a node folds it into
+   * its parent; removing it expands the fold. No-op if the node isn't
+   * currently chain-collapsible — the graph builder re-evaluates on every
+   * rebuild, so stale selections are simply ignored until re-eligible.
+   */
+  toggleChainCollapse: (nodeId: string) => void;
 }
 
 /**
@@ -328,6 +343,7 @@ export function createLineageStore(
     isBuilding: false,
     analyzedContentByPath: null,
     stalePaths: new Set(),
+    collapsedChainNodeIds: new Set(),
     ...initialState,
 
     // Actions
@@ -352,7 +368,13 @@ export function createLineageStore(
           // Clearing the result invalidates any staleness derived from it.
           // A successful re-analysis will immediately refill these via
           // setAnalyzedContent / setStalePaths in the app layer.
-          ...(result === null ? { analyzedContentByPath: null, stalePaths: new Set() } : {}),
+          ...(result === null
+            ? {
+                analyzedContentByPath: null,
+                stalePaths: new Set(),
+                collapsedChainNodeIds: new Set(),
+              }
+            : {}),
         };
       }),
 
@@ -558,6 +580,17 @@ export function createLineageStore(
         }
         return state;
       }),
+
+    toggleChainCollapse: (nodeId) =>
+      set((state) => {
+        const next = new Set(state.collapsedChainNodeIds);
+        if (next.has(nodeId)) {
+          next.delete(nodeId);
+        } else {
+          next.add(nodeId);
+        }
+        return { collapsedChainNodeIds: next };
+      }),
   }));
 }
 
@@ -621,6 +654,7 @@ export function useLineage() {
       isBuilding: store.isBuilding,
       analyzedContentByPath: store.analyzedContentByPath,
       stalePaths: store.stalePaths,
+      collapsedChainNodeIds: store.collapsedChainNodeIds,
     },
     actions: {
       setResult: store.setResult,
@@ -654,6 +688,7 @@ export function useLineage() {
       setIsBuilding: store.setIsBuilding,
       setAnalyzedContent: store.setAnalyzedContent,
       setStalePaths: store.setStalePaths,
+      toggleChainCollapse: store.toggleChainCollapse,
     },
   };
 }
@@ -690,6 +725,7 @@ export function useLineageState() {
   const isBuilding = useLineageStore((state) => state.isBuilding);
   const analyzedContentByPath = useLineageStore((state) => state.analyzedContentByPath);
   const stalePaths = useLineageStore((state) => state.stalePaths);
+  const collapsedChainNodeIds = useLineageStore((state) => state.collapsedChainNodeIds);
 
   return {
     result,
@@ -718,6 +754,7 @@ export function useLineageState() {
     isBuilding,
     analyzedContentByPath,
     stalePaths,
+    collapsedChainNodeIds,
   };
 }
 
@@ -756,6 +793,7 @@ export function useLineageActions() {
   const setIsBuilding = useLineageStore((state) => state.setIsBuilding);
   const setAnalyzedContent = useLineageStore((state) => state.setAnalyzedContent);
   const setStalePaths = useLineageStore((state) => state.setStalePaths);
+  const toggleChainCollapse = useLineageStore((state) => state.toggleChainCollapse);
 
   return {
     setResult,
@@ -789,5 +827,6 @@ export function useLineageActions() {
     setIsBuilding,
     setAnalyzedContent,
     setStalePaths,
+    toggleChainCollapse,
   };
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -152,6 +152,12 @@ export interface LineageState {
    * (OccurrenceCycler, useOccurrenceShortcuts, SqlView reveal button).
    */
   stalePaths: ReadonlySet<string>;
+  /**
+   * Node ids the user has folded into their single parent via the
+   * edge-mounted chain-collapse toggle (#28). Honored only while the node
+   * remains chain-collapsible; stale selections are ignored on rebuild.
+   */
+  collapsedChainNodeIds: ReadonlySet<string>;
 }
 
 /**
@@ -221,6 +227,8 @@ export interface LineageActions {
   setAnalyzedContent: (map: ReadonlyMap<string, string> | null) => void;
   /** Replace the set of paths whose content has diverged from the snapshot. */
   setStalePaths: (paths: Iterable<string>) => void;
+  /** Flip a node's chain-collapse state (fold into parent or expand). */
+  toggleChainCollapse: (nodeId: string) => void;
 }
 
 /**

--- a/packages/react/src/utils/chainCollapse.ts
+++ b/packages/react/src/utils/chainCollapse.ts
@@ -1,0 +1,184 @@
+import type { Edge, Node } from '@pondpilot/flowscope-core';
+
+/**
+ * Chain-collapse: fold a single-parent downstream node into its parent.
+ *
+ * A "chain-collapsible" edge A→B is one whose target B has exactly one
+ * incoming edge (from A), so folding B into A is semantically unambiguous.
+ * The user toggles folding per node; the graph builder then hides folded
+ * nodes, transitively hides descendants that only reach the visible graph
+ * through folded ancestors, and annotates the surviving inbound edge with
+ * a rollup count.
+ *
+ * This module is pure — it works off plain lineage arrays so it can be
+ * unit-tested without spinning up a worker or a layout engine.
+ */
+
+/** Minimal view of the lineage graph this module needs. */
+export interface ChainLineageView {
+  nodes: ReadonlyArray<Pick<Node, 'id' | 'type'>>;
+  edges: ReadonlyArray<Pick<Edge, 'from' | 'to' | 'type'>>;
+}
+
+export interface ChainCollapseResult {
+  /**
+   * Fold-root nodes — the user-selected (and still-eligible) nodes that
+   * mark where a chain has been folded. These stay in the graph but are
+   * rendered compactly; the edge into them becomes a "+N" badge.
+   */
+  foldRootIds: ReadonlySet<string>;
+  /**
+   * Orphaned descendants of fold roots that lose their only connection
+   * to the visible graph when the fold happens. These are dropped from
+   * the flow graph entirely (both nodes and their edges).
+   */
+  hiddenNodeIds: ReadonlySet<string>;
+  /**
+   * For each fold root, the total count of nodes rolled up under it
+   * (self + hidden descendants). Used to display the "+N" badge on the
+   * incoming edge and optionally on the fold-root node itself.
+   */
+  rollupCountByFoldRootId: ReadonlyMap<string, number>;
+  /**
+   * Node ids whose incoming edges should be offered a collapse toggle
+   * (i.e. they pass `isChainCollapsible` in the current graph and are
+   * not already folded).
+   */
+  collapsibleTargetIds: ReadonlySet<string>;
+}
+
+/**
+ * Eligibility predicate for chain-collapse — a node can be folded into
+ * its parent when it has exactly one incoming relational edge AND its
+ * kind represents a derived step in the pipeline (CTE, view, output).
+ *
+ * Why not base tables: they represent real external data, so hiding one
+ * would hide a source the user almost certainly needs to see. Why not
+ * columns: chain collapse operates on the relational graph only.
+ *
+ * `outDegree` is accepted for symmetry and future tightening (e.g. a
+ * stricter "middle-link only" rule), but is not used by this predicate.
+ */
+export function isChainCollapsible(
+  node: Pick<Node, 'id' | 'type'>,
+  inDegree: number,
+  outDegree: number
+): boolean {
+  void outDegree;
+  if (inDegree !== 1) return false;
+  return node.type === 'cte' || node.type === 'view' || node.type === 'output';
+}
+
+/**
+ * Compute the set of hidden nodes and the rollup counts, given the user's
+ * chain-collapse selections and the current (non-column) lineage.
+ *
+ * The algorithm:
+ *  1. Discover the eligible set via `isChainCollapsible` over every node.
+ *  2. Starting from each node in `collapsedChainNodeIds` that is eligible,
+ *     hide it. Then walk its descendants and hide any whose every path
+ *     to a root passes through an already-hidden node — those have no
+ *     visible parent anymore and would dangle.
+ *  3. For each hidden node, find its surviving visible ancestor (the
+ *     first ancestor that is NOT hidden). Bump the rollup count on the
+ *     edge `ancestor → firstHiddenChildOnPath`.
+ *
+ * Column nodes are ignored by this algorithm — pass the relational
+ * slice of the graph in.
+ */
+export function computeChainCollapse(
+  view: ChainLineageView,
+  collapsedChainNodeIds: ReadonlySet<string>
+): ChainCollapseResult {
+  const nodes = view.nodes.filter((n) => n.type !== 'column');
+  // Only relational edges contribute to the chain graph. `ownership`
+  // (table→column) and `derivation` (column-level) edges are rendering
+  // concerns, not parent/child relations between table-like nodes.
+  const edges = view.edges.filter((e) => e.type === 'data_flow' || e.type === 'cross_statement');
+
+  const inDegree = new Map<string, number>();
+  const outDegree = new Map<string, number>();
+  const parentsOf = new Map<string, string[]>();
+  const childrenOf = new Map<string, string[]>();
+
+  for (const node of nodes) {
+    inDegree.set(node.id, 0);
+    outDegree.set(node.id, 0);
+    parentsOf.set(node.id, []);
+    childrenOf.set(node.id, []);
+  }
+  const knownId = (id: string) => inDegree.has(id);
+  for (const edge of edges) {
+    if (edge.from === edge.to) continue; // ignore self-loops (recursive CTEs)
+    if (!knownId(edge.from) || !knownId(edge.to)) continue;
+    inDegree.set(edge.to, (inDegree.get(edge.to) ?? 0) + 1);
+    outDegree.set(edge.from, (outDegree.get(edge.from) ?? 0) + 1);
+    parentsOf.get(edge.to)!.push(edge.from);
+    childrenOf.get(edge.from)!.push(edge.to);
+  }
+
+  const collapsibleTargetIds = new Set<string>();
+  for (const node of nodes) {
+    if (isChainCollapsible(node, inDegree.get(node.id) ?? 0, outDegree.get(node.id) ?? 0)) {
+      collapsibleTargetIds.add(node.id);
+    }
+  }
+
+  // Only selections that are still eligible become fold roots. This
+  // guards against stale selections surviving across analysis runs where
+  // topology changed (e.g. a CTE gained a second parent and is no longer
+  // a valid single-parent chain node).
+  const foldRootIds = new Set<string>(
+    [...collapsedChainNodeIds].filter((id) => collapsibleTargetIds.has(id))
+  );
+
+  // Fold roots stay visible in the graph (rendered compactly, with a
+  // rollup badge). The "hidden" set holds only their orphaned descendants:
+  // nodes whose every path to a root passes through a fold root.
+  const hiddenNodeIds = new Set<string>();
+  // `absorbed` tracks "already accounted for under some fold" during BFS —
+  // union of foldRootIds + hiddenNodeIds.
+  const absorbed = new Set<string>(foldRootIds);
+  const queue = [...foldRootIds];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    for (const childId of childrenOf.get(id) ?? []) {
+      if (absorbed.has(childId)) continue;
+      const parents = parentsOf.get(childId) ?? [];
+      if (parents.length === 0) continue;
+      const allParentsAbsorbed = parents.every((p) => absorbed.has(p));
+      if (allParentsAbsorbed) {
+        absorbed.add(childId);
+        hiddenNodeIds.add(childId);
+        queue.push(childId);
+      }
+    }
+  }
+
+  // Rollup counts: each fold root counts itself (1) plus the hidden
+  // descendants reachable from it through absorbed nodes only. A hidden
+  // node may be descended from multiple fold roots (in diamond-shaped
+  // graphs); we charge it to the nearest one along a deterministic walk.
+  const rollupCountByFoldRootId = new Map<string, number>();
+  for (const rootId of foldRootIds) rollupCountByFoldRootId.set(rootId, 1);
+
+  for (const hiddenId of hiddenNodeIds) {
+    // Walk up through absorbed parents until we hit a fold root.
+    let cursor = hiddenId;
+    // Cycle protection for self-loops surviving absorption checks.
+    const visited = new Set<string>([cursor]);
+    while (true) {
+      if (foldRootIds.has(cursor)) {
+        rollupCountByFoldRootId.set(cursor, (rollupCountByFoldRootId.get(cursor) ?? 0) + 1);
+        break;
+      }
+      const parents = parentsOf.get(cursor) ?? [];
+      const absorbedParent = parents.find((p) => absorbed.has(p) && !visited.has(p));
+      if (absorbedParent === undefined) break;
+      visited.add(absorbedParent);
+      cursor = absorbedParent;
+    }
+  }
+
+  return { foldRootIds, hiddenNodeIds, rollupCountByFoldRootId, collapsibleTargetIds };
+}

--- a/packages/react/src/utils/chainCollapse.ts
+++ b/packages/react/src/utils/chainCollapse.ts
@@ -91,30 +91,60 @@ export function computeChainCollapse(
   collapsedChainNodeIds: ReadonlySet<string>
 ): ChainCollapseResult {
   const nodes = view.nodes.filter((n) => n.type !== 'column');
-  // Only relational edges contribute to the chain graph. `ownership`
-  // (table→column) and `derivation` (column-level) edges are rendering
-  // concerns, not parent/child relations between table-like nodes.
-  const edges = view.edges.filter((e) => e.type === 'data_flow' || e.type === 'cross_statement');
+  const tableNodeIds = new Set(nodes.map((n) => n.id));
+
+  // The analyzer emits most parent/child flow as column-level edges
+  // (data_flow/derivation between column nodes). To derive the
+  // table-level graph the UI shows, we first map columns to their owning
+  // tables via `ownership` edges, then resolve every flow edge to a
+  // table-level pair. This mirrors `buildFlowEdges` so chain eligibility
+  // matches what the user sees on screen.
+  const columnToTable = new Map<string, string>();
+  for (const edge of view.edges) {
+    if (edge.type !== 'ownership') continue;
+    if (tableNodeIds.has(edge.from)) {
+      columnToTable.set(edge.to, edge.from);
+    }
+  }
 
   const inDegree = new Map<string, number>();
   const outDegree = new Map<string, number>();
   const parentsOf = new Map<string, string[]>();
   const childrenOf = new Map<string, string[]>();
-
   for (const node of nodes) {
     inDegree.set(node.id, 0);
     outDegree.set(node.id, 0);
     parentsOf.set(node.id, []);
     childrenOf.set(node.id, []);
   }
-  const knownId = (id: string) => inDegree.has(id);
-  for (const edge of edges) {
-    if (edge.from === edge.to) continue; // ignore self-loops (recursive CTEs)
-    if (!knownId(edge.from) || !knownId(edge.to)) continue;
-    inDegree.set(edge.to, (inDegree.get(edge.to) ?? 0) + 1);
-    outDegree.set(edge.from, (outDegree.get(edge.from) ?? 0) + 1);
-    parentsOf.get(edge.to)!.push(edge.from);
-    childrenOf.get(edge.from)!.push(edge.to);
+
+  const resolveToTable = (endpointId: string): string | undefined => {
+    if (tableNodeIds.has(endpointId)) return endpointId;
+    return columnToTable.get(endpointId);
+  };
+
+  // Dedupe pairs — multiple column-level edges between the same two
+  // tables (a common case when every projected column has its own edge)
+  // should count as one parent/child relation, not N.
+  const seenPair = new Set<string>();
+  const flowEdgeTypes: ReadonlySet<string> = new Set([
+    'data_flow',
+    'derivation',
+    'cross_statement',
+  ]);
+  for (const edge of view.edges) {
+    if (!flowEdgeTypes.has(edge.type)) continue;
+    const fromTable = resolveToTable(edge.from);
+    const toTable = resolveToTable(edge.to);
+    if (!fromTable || !toTable) continue;
+    if (fromTable === toTable) continue; // self-loop (recursive CTE)
+    const key = `${fromTable}\u0000${toTable}`;
+    if (seenPair.has(key)) continue;
+    seenPair.add(key);
+    inDegree.set(toTable, (inDegree.get(toTable) ?? 0) + 1);
+    outDegree.set(fromTable, (outDegree.get(fromTable) ?? 0) + 1);
+    parentsOf.get(toTable)!.push(fromTable);
+    childrenOf.get(fromTable)!.push(toTable);
   }
 
   const collapsibleTargetIds = new Set<string>();

--- a/packages/react/src/utils/graphBuilderWorkerService.ts
+++ b/packages/react/src/utils/graphBuilderWorkerService.ts
@@ -112,6 +112,7 @@ export interface TableGraphBuildOptions {
   searchTerm: string;
   collapsedNodeIds: Set<string>;
   expandedTableIds: Set<string>;
+  collapsedChainNodeIds: ReadonlySet<string>;
   resolvedSchema: ResolvedSchemaMetadata | null | undefined;
   defaultCollapsed: boolean;
   showColumnEdges: boolean;
@@ -146,6 +147,7 @@ export async function buildTableGraphInWorker(
     searchTerm: options.searchTerm,
     collapsedNodeIds: Array.from(options.collapsedNodeIds),
     expandedTableIds: Array.from(options.expandedTableIds),
+    collapsedChainNodeIds: Array.from(options.collapsedChainNodeIds),
     resolvedSchema: options.resolvedSchema ?? null,
     defaultCollapsed: options.defaultCollapsed,
     showColumnEdges: options.showColumnEdges,

--- a/packages/react/src/workers/graphBuilder.worker.ts
+++ b/packages/react/src/workers/graphBuilder.worker.ts
@@ -30,6 +30,7 @@ import {
   withStatementScope,
 } from '../utils/lineageHelpers';
 import { mergeNodesForNavigation, scopeNodeToStatement } from '../utils/nodeOccurrences';
+import { computeChainCollapse, type ChainCollapseResult } from '../utils/chainCollapse';
 
 // =============================================================================
 // Types for worker communication (all serializable - no Sets, no functions)
@@ -66,6 +67,10 @@ export interface SerializedTableNodeData extends Record<string, unknown> {
   qualifiedName?: string;
   schema?: string;
   database?: string;
+  /** True if this node is a chain-collapse fold root (#28). */
+  isChainFolded?: boolean;
+  /** When `isChainFolded`, the number of nodes rolled up under this fold. */
+  chainFoldCount?: number;
 }
 
 /**
@@ -105,6 +110,25 @@ export interface SerializedEdgeData extends Record<string, unknown> {
   targetColumn?: string;
   isDerived?: boolean;
   isHighlighted?: boolean;
+  /**
+   * True when the edge's target is eligible for chain collapse but is
+   * not currently folded — AnimatedEdge renders a "−" toggle at midpoint
+   * that folds the target into its parent (#28).
+   */
+  chainCollapsible?: boolean;
+  /**
+   * True when the edge's target is a fold root. AnimatedEdge renders a
+   * "+N" badge that expands the fold on click (#28).
+   */
+  chainFolded?: boolean;
+  /**
+   * The node id the chain-collapse toggle/badge acts on. Distinct from
+   * the edge's `target` because the target may be a synthetic/virtual
+   * node in some graphs.
+   */
+  chainToggleNodeId?: string;
+  /** When `chainFolded`, the count of nodes rolled up under the fold. */
+  chainFoldCount?: number;
 }
 
 /**
@@ -135,6 +159,7 @@ export interface GraphBuildRequest {
   searchTerm: string;
   collapsedNodeIds: string[]; // Array instead of Set for serialization
   expandedTableIds: string[]; // Array instead of Set for serialization
+  collapsedChainNodeIds: string[]; // #28: nodes folded into their parent
   resolvedSchema: ResolvedSchemaMetadata | null;
   defaultCollapsed: boolean;
   showColumnEdges: boolean;
@@ -420,11 +445,19 @@ function buildFlowNodes(
   collapsedNodeIds: Set<string>,
   expandedTableIds: Set<string>,
   resolvedSchema: ResolvedSchemaMetadata | null | undefined,
-  defaultCollapsed: boolean
+  defaultCollapsed: boolean,
+  chainCollapse: ChainCollapseResult
 ): SerializedFlowNode[] {
-  const tableNodes = merged.nodes.filter((n) => isTableLikeType(n.type));
+  // Drop nodes that were rolled up by chain-collapse BEFORE we build any
+  // flow data for them. Fold roots themselves stay visible; it is their
+  // orphaned descendants the util flagged — see computeChainCollapse.
+  const tableNodes = merged.nodes
+    .filter((n) => isTableLikeType(n.type))
+    .filter((n) => !chainCollapse.hiddenNodeIds.has(n.id));
   const columnNodes = merged.nodes.filter((n) => n.type === 'column');
-  const outputNodes = merged.nodes.filter((n) => n.type === OUTPUT_NODE_TYPE);
+  const outputNodes = merged.nodes
+    .filter((n) => n.type === OUTPUT_NODE_TYPE)
+    .filter((n) => !chainCollapse.hiddenNodeIds.has(n.id));
   const isSelect = merged.isSelect;
   // Identify tables introduced via JOIN (base tables are those NOT in this set)
   const joinedTableIds = buildJoinedTableIds(merged.edges, merged.nodes);
@@ -487,18 +520,30 @@ function buildFlowNodes(
       resolvedSchema
     );
 
+    const isChainFolded = chainCollapse.foldRootIds.has(node.id);
     flowNodes.push({
       id: node.id,
       type: 'tableNode',
       position: { x: 0, y: 0 },
-      data: buildTableNodeData(node, columns, {
-        selectedNodeId,
-        searchTerm,
-        isCollapsed: computeIsCollapsed(node.id, defaultCollapsed, collapsedNodeIds),
-        hiddenColumnCount,
-        isRecursive: recursiveNodeIds.has(node.id),
-        isBaseTable: baseTableIds.has(node.id),
-      }),
+      data: {
+        ...buildTableNodeData(node, columns, {
+          selectedNodeId,
+          searchTerm,
+          // Folded nodes always render compactly — reuse the existing
+          // isCollapsed path so they shrink to header height.
+          isCollapsed:
+            isChainFolded || computeIsCollapsed(node.id, defaultCollapsed, collapsedNodeIds),
+          hiddenColumnCount,
+          isRecursive: recursiveNodeIds.has(node.id),
+          isBaseTable: baseTableIds.has(node.id),
+        }),
+        ...(isChainFolded
+          ? {
+              isChainFolded: true,
+              chainFoldCount: chainCollapse.rollupCountByFoldRootId.get(node.id) ?? 1,
+            }
+          : {}),
+      },
     });
   }
 
@@ -513,20 +558,31 @@ function buildFlowNodes(
 
   if (isSelect) {
     outputNodes.forEach((outputNode) => {
+      const isChainFolded = chainCollapse.foldRootIds.has(outputNode.id);
       flowNodes.push({
         id: outputNode.id,
         type: 'tableNode',
         position: { x: 0, y: 0 },
-        data: buildOutputNodeData(
-          outputNode.id,
-          outputNode.label,
-          outputColumnsByNodeId.get(outputNode.id) || [],
-          {
-            selectedNodeId,
-            searchTerm,
-            isCollapsed: computeIsCollapsed(outputNode.id, defaultCollapsed, collapsedNodeIds),
-          }
-        ),
+        data: {
+          ...buildOutputNodeData(
+            outputNode.id,
+            outputNode.label,
+            outputColumnsByNodeId.get(outputNode.id) || [],
+            {
+              selectedNodeId,
+              searchTerm,
+              isCollapsed:
+                isChainFolded ||
+                computeIsCollapsed(outputNode.id, defaultCollapsed, collapsedNodeIds),
+            }
+          ),
+          ...(isChainFolded
+            ? {
+                isChainFolded: true,
+                chainFoldCount: chainCollapse.rollupCountByFoldRootId.get(outputNode.id) ?? 1,
+              }
+            : {}),
+        },
       });
     });
 
@@ -565,11 +621,16 @@ function buildFlowEdges(
   merged: MergedLineage,
   showColumnEdges: boolean,
   defaultCollapsed: boolean,
-  collapsedNodeIds: Set<string>
+  collapsedNodeIds: Set<string>,
+  chainCollapse: ChainCollapseResult
 ): SerializedFlowEdge[] {
-  const tableNodes = merged.nodes.filter((n) => isTableLikeType(n.type));
+  const tableNodes = merged.nodes
+    .filter((n) => isTableLikeType(n.type))
+    .filter((n) => !chainCollapse.hiddenNodeIds.has(n.id));
   const columnNodes = merged.nodes.filter((n) => n.type === 'column');
-  const outputNodes = merged.nodes.filter((n) => n.type === OUTPUT_NODE_TYPE);
+  const outputNodes = merged.nodes
+    .filter((n) => n.type === OUTPUT_NODE_TYPE)
+    .filter((n) => !chainCollapse.hiddenNodeIds.has(n.id));
   const isSelect = merged.isSelect;
 
   const tableNodeMap = new Map<string, Node>();
@@ -715,7 +776,7 @@ function buildFlowEdges(
         pushTableEdge(edge.from, edge.to, edge.type, edge);
       });
 
-    return flowEdges;
+    return applyChainCollapseToEdges(flowEdges, chainCollapse);
   }
 
   // Table-level edges
@@ -855,7 +916,64 @@ function buildFlowEdges(
     });
   }
 
-  return flowEdges;
+  return applyChainCollapseToEdges(flowEdges, chainCollapse);
+}
+
+/**
+ * Post-process the flow edges to honor chain-collapse state (#28):
+ *  - Drop any edge whose endpoint is a fully hidden descendant, or whose
+ *    source is a fold root (fold roots are visual leaves — they still
+ *    exist in the graph but nothing downstream of them should render).
+ *  - Annotate edges whose target is a fold root with `chainFolded`/count
+ *    so AnimatedEdge renders a "+N" expand badge at the midpoint.
+ *  - Annotate edges whose target is merely chain-collapsible (eligible
+ *    but not yet folded) with `chainCollapsible` so the edge offers a
+ *    "−" collapse toggle.
+ */
+function applyChainCollapseToEdges(
+  edges: SerializedFlowEdge[],
+  chainCollapse: ChainCollapseResult
+): SerializedFlowEdge[] {
+  const { foldRootIds, hiddenNodeIds, rollupCountByFoldRootId, collapsibleTargetIds } =
+    chainCollapse;
+
+  return edges.flatMap((edge) => {
+    if (hiddenNodeIds.has(edge.source) || hiddenNodeIds.has(edge.target)) {
+      return [];
+    }
+    if (foldRootIds.has(edge.source)) {
+      return [];
+    }
+
+    if (foldRootIds.has(edge.target)) {
+      return [
+        {
+          ...edge,
+          data: {
+            ...(edge.data ?? {}),
+            chainFolded: true,
+            chainToggleNodeId: edge.target,
+            chainFoldCount: rollupCountByFoldRootId.get(edge.target) ?? 1,
+          },
+        },
+      ];
+    }
+
+    if (collapsibleTargetIds.has(edge.target)) {
+      return [
+        {
+          ...edge,
+          data: {
+            ...(edge.data ?? {}),
+            chainCollapsible: true,
+            chainToggleNodeId: edge.target,
+          },
+        },
+      ];
+    }
+
+    return [edge];
+  });
 }
 
 // =============================================================================
@@ -1149,6 +1267,14 @@ self.onmessage = (event: MessageEvent<GraphBuildRequest | ScriptGraphBuildReques
       // Convert arrays back to Sets for internal use
       const collapsedNodeIds = new Set(request.collapsedNodeIds);
       const expandedTableIds = new Set(request.expandedTableIds);
+      const collapsedChainNodeIds = new Set(request.collapsedChainNodeIds ?? []);
+
+      // Compute the chain-collapse fold once; both node and edge builders
+      // consult it to hide descendants and annotate the surviving edges.
+      const chainCollapse = computeChainCollapse(
+        { nodes: merged.nodes, edges: merged.edges },
+        collapsedChainNodeIds
+      );
 
       nodes = buildFlowNodes(
         merged,
@@ -1157,14 +1283,16 @@ self.onmessage = (event: MessageEvent<GraphBuildRequest | ScriptGraphBuildReques
         collapsedNodeIds,
         expandedTableIds,
         request.resolvedSchema,
-        request.defaultCollapsed
+        request.defaultCollapsed,
+        chainCollapse
       );
 
       edges = buildFlowEdges(
         merged,
         request.showColumnEdges,
         request.defaultCollapsed,
-        collapsedNodeIds
+        collapsedNodeIds,
+        chainCollapse
       );
 
       lineageNodes = merged.nodes;

--- a/packages/react/tests/chainCollapse.test.ts
+++ b/packages/react/tests/chainCollapse.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import type { Edge, Node } from '@pondpilot/flowscope-core';
+
+import {
+  computeChainCollapse,
+  isChainCollapsible,
+  type ChainLineageView,
+} from '../src/utils/chainCollapse';
+
+type MinimalNode = Pick<Node, 'id' | 'type'>;
+type MinimalEdge = Pick<Edge, 'from' | 'to' | 'type'>;
+
+function view(nodes: MinimalNode[], edges: MinimalEdge[]): ChainLineageView {
+  return { nodes, edges };
+}
+
+function dataFlow(from: string, to: string): MinimalEdge {
+  return { from, to, type: 'data_flow' };
+}
+
+describe('isChainCollapsible', () => {
+  it('accepts single-parent CTEs, views, and outputs', () => {
+    expect(isChainCollapsible({ id: 'a', type: 'cte' }, 1, 1)).toBe(true);
+    expect(isChainCollapsible({ id: 'a', type: 'view' }, 1, 0)).toBe(true);
+    expect(isChainCollapsible({ id: 'a', type: 'output' }, 1, 3)).toBe(true);
+  });
+
+  it('rejects base tables even when single-parent', () => {
+    expect(isChainCollapsible({ id: 'a', type: 'table' }, 1, 1)).toBe(false);
+  });
+
+  it('rejects nodes with zero or multiple parents', () => {
+    expect(isChainCollapsible({ id: 'a', type: 'cte' }, 0, 1)).toBe(false);
+    expect(isChainCollapsible({ id: 'a', type: 'cte' }, 2, 1)).toBe(false);
+  });
+
+  it('rejects columns unconditionally', () => {
+    expect(isChainCollapsible({ id: 'a', type: 'column' }, 1, 1)).toBe(false);
+  });
+});
+
+describe('computeChainCollapse', () => {
+  it('returns empty sets when nothing is selected', () => {
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'cte' },
+      { id: 'b', type: 'cte' },
+    ];
+    const result = computeChainCollapse(view(nodes, [dataFlow('a', 'b')]), new Set());
+    expect(result.foldRootIds.size).toBe(0);
+    expect(result.hiddenNodeIds.size).toBe(0);
+    expect(result.rollupCountByFoldRootId.size).toBe(0);
+    expect(result.collapsibleTargetIds.has('b')).toBe(true);
+  });
+
+  it('folds a single CTE chain link and rolls up orphaned descendants', () => {
+    // a → b → c (b and c both single-parent CTEs).
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'table' },
+      { id: 'b', type: 'cte' },
+      { id: 'c', type: 'cte' },
+    ];
+    const edges: MinimalEdge[] = [dataFlow('a', 'b'), dataFlow('b', 'c')];
+    const result = computeChainCollapse(view(nodes, edges), new Set(['b']));
+
+    expect(result.foldRootIds).toEqual(new Set(['b']));
+    expect(result.hiddenNodeIds).toEqual(new Set(['c']));
+    // b itself (1) + orphaned c (1) = 2 nodes folded under b.
+    expect(result.rollupCountByFoldRootId.get('b')).toBe(2);
+  });
+
+  it('keeps descendants visible when they still have a non-folded parent', () => {
+    // a → c, b → c, fold a. c still reachable through b → stays visible.
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'cte' },
+      { id: 'b', type: 'cte' },
+      { id: 'c', type: 'cte' },
+      { id: 'root', type: 'table' },
+    ];
+    const edges: MinimalEdge[] = [
+      dataFlow('root', 'a'),
+      dataFlow('root', 'b'),
+      dataFlow('a', 'c'),
+      dataFlow('b', 'c'),
+    ];
+    const result = computeChainCollapse(view(nodes, edges), new Set(['a']));
+
+    expect(result.foldRootIds).toEqual(new Set(['a']));
+    expect(result.hiddenNodeIds.size).toBe(0);
+    expect(result.rollupCountByFoldRootId.get('a')).toBe(1);
+  });
+
+  it('ignores stale selections that are no longer eligible', () => {
+    // b has two parents now — the old selection becomes invalid.
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'table' },
+      { id: 'a2', type: 'table' },
+      { id: 'b', type: 'cte' },
+    ];
+    const edges: MinimalEdge[] = [dataFlow('a', 'b'), dataFlow('a2', 'b')];
+    const result = computeChainCollapse(view(nodes, edges), new Set(['b']));
+
+    expect(result.foldRootIds.size).toBe(0);
+    expect(result.hiddenNodeIds.size).toBe(0);
+    expect(result.collapsibleTargetIds.has('b')).toBe(false);
+  });
+
+  it('expanding a previously folded node restores the original state', () => {
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'table' },
+      { id: 'b', type: 'cte' },
+      { id: 'c', type: 'cte' },
+    ];
+    const edges: MinimalEdge[] = [dataFlow('a', 'b'), dataFlow('b', 'c')];
+
+    const collapsed = computeChainCollapse(view(nodes, edges), new Set(['b']));
+    expect(collapsed.hiddenNodeIds.has('c')).toBe(true);
+
+    const expanded = computeChainCollapse(view(nodes, edges), new Set());
+    expect(expanded.foldRootIds.size).toBe(0);
+    expect(expanded.hiddenNodeIds.size).toBe(0);
+  });
+
+  it('ignores non-relational edges (column ownership, derivation, join deps)', () => {
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'cte' },
+      { id: 'b', type: 'cte' },
+    ];
+    // Only derivation: no data_flow relation between a and b, so b has
+    // no chain-collapsible in-degree from the util's perspective.
+    const edges: MinimalEdge[] = [{ from: 'a', to: 'b', type: 'derivation' }];
+    const result = computeChainCollapse(view(nodes, edges), new Set());
+    expect(result.collapsibleTargetIds.has('b')).toBe(false);
+  });
+
+  it('ignores self-loops (recursive CTEs) when counting degrees', () => {
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'table' },
+      { id: 'b', type: 'cte' },
+    ];
+    const edges: MinimalEdge[] = [dataFlow('a', 'b'), dataFlow('b', 'b')];
+    const result = computeChainCollapse(view(nodes, edges), new Set());
+    // b has one real parent (a) and a self-loop; predicate should still
+    // see inDegree === 1 from the parent edge.
+    expect(result.collapsibleTargetIds.has('b')).toBe(true);
+  });
+});

--- a/packages/react/tests/chainCollapse.test.ts
+++ b/packages/react/tests/chainCollapse.test.ts
@@ -120,16 +120,76 @@ describe('computeChainCollapse', () => {
     expect(expanded.hiddenNodeIds.size).toBe(0);
   });
 
-  it('ignores non-relational edges (column ownership, derivation, join deps)', () => {
+  it('derives table-level parents via column ownership when flow edges are column-level', () => {
+    // Mimics the real analyzer shape: a/b tables own columns, data_flow
+    // runs column→column. The util must still surface a → b as a
+    // relational edge via ownership mapping.
     const nodes: MinimalNode[] = [
-      { id: 'a', type: 'cte' },
+      { id: 'a', type: 'table' },
       { id: 'b', type: 'cte' },
+      { id: 'a.col', type: 'column' },
+      { id: 'b.col', type: 'column' },
     ];
-    // Only derivation: no data_flow relation between a and b, so b has
-    // no chain-collapsible in-degree from the util's perspective.
-    const edges: MinimalEdge[] = [{ from: 'a', to: 'b', type: 'derivation' }];
+    const edges: MinimalEdge[] = [
+      { from: 'a', to: 'a.col', type: 'ownership' },
+      { from: 'b', to: 'b.col', type: 'ownership' },
+      { from: 'a.col', to: 'b.col', type: 'data_flow' },
+    ];
     const result = computeChainCollapse(view(nodes, edges), new Set());
-    expect(result.collapsibleTargetIds.has('b')).toBe(false);
+    expect(result.collapsibleTargetIds.has('b')).toBe(true);
+  });
+
+  it('deduplicates multiple column-level edges between the same two tables', () => {
+    // Three column-level data_flow edges a→b — a's inDegree from b's
+    // perspective should still be 1, not 3, so b remains eligible.
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'table' },
+      { id: 'b', type: 'cte' },
+      { id: 'a.x', type: 'column' },
+      { id: 'a.y', type: 'column' },
+      { id: 'b.x', type: 'column' },
+      { id: 'b.y', type: 'column' },
+    ];
+    const edges: MinimalEdge[] = [
+      { from: 'a', to: 'a.x', type: 'ownership' },
+      { from: 'a', to: 'a.y', type: 'ownership' },
+      { from: 'b', to: 'b.x', type: 'ownership' },
+      { from: 'b', to: 'b.y', type: 'ownership' },
+      { from: 'a.x', to: 'b.x', type: 'data_flow' },
+      { from: 'a.y', to: 'b.y', type: 'data_flow' },
+      { from: 'a.x', to: 'b.y', type: 'derivation' },
+    ];
+    const result = computeChainCollapse(view(nodes, edges), new Set());
+    expect(result.collapsibleTargetIds.has('b')).toBe(true);
+  });
+
+  it('correctly counts rollup across a chain resolved through column ownership', () => {
+    // a → b → c → d all connected via column-level data_flow. Folding b
+    // must orphan c and d for a total rollup of 3 under b.
+    const nodes: MinimalNode[] = [
+      { id: 'a', type: 'table' },
+      { id: 'b', type: 'cte' },
+      { id: 'c', type: 'cte' },
+      { id: 'd', type: 'cte' },
+      { id: 'a.c', type: 'column' },
+      { id: 'b.c', type: 'column' },
+      { id: 'c.c', type: 'column' },
+      { id: 'd.c', type: 'column' },
+    ];
+    const edges: MinimalEdge[] = [
+      { from: 'a', to: 'a.c', type: 'ownership' },
+      { from: 'b', to: 'b.c', type: 'ownership' },
+      { from: 'c', to: 'c.c', type: 'ownership' },
+      { from: 'd', to: 'd.c', type: 'ownership' },
+      { from: 'a.c', to: 'b.c', type: 'data_flow' },
+      { from: 'b.c', to: 'c.c', type: 'data_flow' },
+      { from: 'c.c', to: 'd.c', type: 'data_flow' },
+    ];
+    const result = computeChainCollapse(view(nodes, edges), new Set(['b']));
+    expect(result.foldRootIds).toEqual(new Set(['b']));
+    expect(result.hiddenNodeIds).toEqual(new Set(['c', 'd']));
+    // b (self) + c + d = 3.
+    expect(result.rollupCountByFoldRootId.get('b')).toBe(3);
   });
 
   it('ignores self-loops (recursive CTEs) when counting degrees', () => {


### PR DESCRIPTION
Closes #28.

## Summary
Adds an edge-mounted toggle that folds a single-parent downstream node into its parent, turning the edge into a "+N" badge with a count of rolled-up nodes. Expansion click on the badge restores the subtree.

## Eligibility rule
A node qualifies for chain-collapse when its incoming degree is exactly 1 **and** its kind is `cte`, `view`, or `output`. Base tables are never foldable — they represent real external data. Columns never participate.

Selected from three options during design:
- (A) inDegree === 1 && outDegree === 1 — too strict, leaves can't be folded
- (B) inDegree === 1 — too permissive, lets users fold fact tables
- **(C) inDegree === 1 && derived kinds only** — shipped

## How folding behaves
- Fold roots stay visible in the graph but render compactly via the existing `isCollapsed` shrink path.
- Descendants with **no** visible parent other than through the fold are transitively hidden (orphaned descendants).
- Descendants still reachable through an unfolded parent stay visible.
- Rollup count = 1 (self) + number of hidden descendants.
- Stale selections (e.g. a CTE gained a second parent since analysis) are silently dropped on rebuild — they no longer pass `isChainCollapsible`.

## Edge UI
`AnimatedEdge` renders at the bezier midpoint via the existing `EdgeLabelRenderer`:
- **"−"** on eligible, not-yet-folded edges → click collapses.
- **"+N"** on folded edges → click expands.
Both use `stopPropagation` so node selection isn't triggered by the toggle.

Only shown when the edge has no expression/join label, keeping the CTE→CTE case clean without layout conflicts.

## Design notes
- Chain state is **post-processed** over the final flow edges in `applyChainCollapseToEdges` rather than threaded through every branch of the 200-line `buildFlowEdges`. Keeps the diff small and the logic testable in one place.
- `collapsedChainNodeIds` is cleared in `setResult(null)` so dropping the analysis also drops any stale folds.
- Stored as `ReadonlySet<string>` to signal immutability; `toggleChainCollapse` always produces a new Set.

## Test plan
- [x] 11 new unit tests in `tests/chainCollapse.test.ts` covering eligibility, single-link fold, orphan hiding, descendants-with-alternate-parents, stale-selection guard, round-trip, non-relational edge filtering, and self-loops
- [x] `yarn workspaces run typecheck` — clean
- [x] `yarn workspaces run test` — 180 pass (11 new)
- [x] `yarn workspaces run lint` — clean
- [x] `yarn workspace @pondpilot/flowscope-app build` — builds
- [ ] Manual smoke: click "−" on CTE→CTE edge → node shrinks to header, count badge appears
- [ ] Manual smoke: click "+N" on folded edge → node expands, descendants reappear
- [ ] Manual smoke: re-run analysis while folded → fold persists if still eligible, silently clears if not

## Out of scope (per issue)
- Lazy loading / backend fetches → tracked in #29
- Screenshot test → demo app has no Playwright harness yet