### PR TITLE
feat: SQL IntelliSense in SqlView + VS Code (#26)

### DIFF
--- a/app/src/components/EditorArea.tsx
+++ b/app/src/components/EditorArea.tsx
@@ -299,6 +299,7 @@ export function EditorArea({
             analyzedSourceName={
               sqlViewMode === 'template' ? activeFile.path || activeFile.name : undefined
             }
+            dialect={currentProject.dialect}
           />
         </ErrorBoundary>
         {isReadOnly && (

--- a/app/src/components/SchemaEditor.tsx
+++ b/app/src/components/SchemaEditor.tsx
@@ -26,6 +26,7 @@ export function SchemaEditor({
   open,
   onOpenChange,
   schemaSQL,
+  dialect,
   onSave,
   isReadOnly = false,
 }: SchemaEditorProps) {
@@ -74,6 +75,7 @@ export function SchemaEditor({
             className="h-full"
             editable={!isReadOnly}
             isDark={isDark}
+            dialect={dialect}
           />
         </div>
 

--- a/packages/react/src/completion/index.ts
+++ b/packages/react/src/completion/index.ts
@@ -1,0 +1,3 @@
+export { mapCompletionItem } from './mapCompletionItem';
+export { createSqlCompletionSource } from './sqlCompletionSource';
+export type { SqlCompletionSourceOptions } from './sqlCompletionSource';

--- a/packages/react/src/completion/mapCompletionItem.ts
+++ b/packages/react/src/completion/mapCompletionItem.ts
@@ -27,9 +27,11 @@ const FALLBACK_DETAIL: Record<CompletionItemKind, string> = {
 };
 
 /**
- * Engine scores are context-weighted and span 0–1000+, while CodeMirror's
- * `boost` is a small adjustment applied after its own fuzzy-match score.
- * Scaling down keeps the relative ordering without drowning CM's matcher.
+ * Engine scores are context-weighted and typically span 0–1000+, while
+ * CodeMirror's `boost` is a small adjustment applied after its own fuzzy-match
+ * score (commonly used in the range roughly -10..+10). Dividing by 100 maps
+ * engine scores into that range, preserving relative ordering without
+ * overwhelming CM's matcher. Adjust if the engine's score range changes.
  */
 const BOOST_SCALE = 100;
 

--- a/packages/react/src/completion/mapCompletionItem.ts
+++ b/packages/react/src/completion/mapCompletionItem.ts
@@ -1,0 +1,50 @@
+import type { Completion } from '@codemirror/autocomplete';
+import type { CompletionItem, CompletionItemKind } from '@pondpilot/flowscope-core';
+
+/**
+ * CodeMirror renders each completion's icon from the `type` field. The
+ * flowscope engine's kinds don't all map one-to-one, so we pick the CM
+ * built-in that reads best in a generic SQL context.
+ */
+const CM_TYPE_BY_KIND: Record<CompletionItemKind, string> = {
+  keyword: 'keyword',
+  operator: 'keyword',
+  function: 'function',
+  snippet: 'text',
+  table: 'class',
+  schemaTable: 'class',
+  column: 'property',
+};
+
+const FALLBACK_DETAIL: Record<CompletionItemKind, string> = {
+  keyword: 'keyword',
+  operator: 'operator',
+  function: 'function',
+  snippet: 'snippet',
+  table: 'table',
+  schemaTable: 'schema table',
+  column: 'column',
+};
+
+/**
+ * Engine scores are context-weighted and span 0–1000+, while CodeMirror's
+ * `boost` is a small adjustment applied after its own fuzzy-match score.
+ * Scaling down keeps the relative ordering without drowning CM's matcher.
+ */
+const BOOST_SCALE = 100;
+
+export function mapCompletionItem(item: CompletionItem): Completion {
+  const detail = item.detail ?? FALLBACK_DETAIL[item.kind];
+  const completion: Completion = {
+    label: item.label,
+    type: CM_TYPE_BY_KIND[item.kind],
+    detail,
+    boost: item.score / BOOST_SCALE,
+  };
+
+  if (item.insertText !== item.label) {
+    completion.apply = item.insertText;
+  }
+
+  return completion;
+}

--- a/packages/react/src/completion/sqlCompletionSource.ts
+++ b/packages/react/src/completion/sqlCompletionSource.ts
@@ -89,6 +89,11 @@ export function createSqlCompletionSource(
         return null;
       }
 
+      if (result.error) {
+        reportCompletionError(new Error(result.error), onError);
+        return null;
+      }
+
       if (!result.shouldShow || result.items.length === 0) {
         return null;
       }

--- a/packages/react/src/completion/sqlCompletionSource.ts
+++ b/packages/react/src/completion/sqlCompletionSource.ts
@@ -1,0 +1,77 @@
+import type {
+  CompletionContext,
+  CompletionResult,
+  CompletionSource,
+} from '@codemirror/autocomplete';
+import { completionItems, type Dialect, type SchemaMetadata } from '@pondpilot/flowscope-core';
+
+import { mapCompletionItem } from './mapCompletionItem';
+
+export interface SqlCompletionSourceOptions {
+  /** SQL dialect driving keyword/function filtering. Defaults to 'generic'. */
+  getDialect?: () => Dialect;
+  /** Optional schema catalog passed through to the engine for column resolution. */
+  getSchema?: () => SchemaMetadata | undefined;
+  /** Hook to surface engine errors without crashing the editor. */
+  onError?: (error: unknown) => void;
+}
+
+/** Re-query only while the user is still typing within a single identifier. */
+const IDENTIFIER_CONTINUATION = /^[\w$]*$/;
+
+/**
+ * CodeMirror `CompletionSource` backed by flowscope's engine.
+ *
+ * The engine is multi-statement aware and handles clause detection itself, so
+ * we pass the full document plus the UTF-16 cursor offset (CodeMirror positions
+ * are UTF-16 code units, which matches `encoding: 'utf16'` on the request).
+ */
+export function createSqlCompletionSource(
+  options: SqlCompletionSourceOptions = {}
+): CompletionSource {
+  const { getDialect, getSchema, onError } = options;
+  let requestCounter = 0;
+
+  return async (context: CompletionContext): Promise<CompletionResult | null> => {
+    const requestId = ++requestCounter;
+    const sql = context.state.doc.toString();
+    const cursorOffset = context.pos;
+    const dialect = getDialect?.() ?? 'generic';
+    const schema = getSchema?.();
+
+    try {
+      const result = await completionItems({
+        sql,
+        dialect,
+        cursorOffset,
+        schema,
+        encoding: 'utf16',
+      });
+
+      if (context.aborted || requestId !== requestCounter) {
+        return null;
+      }
+
+      if (!result.shouldShow || result.items.length === 0) {
+        return null;
+      }
+
+      const token = result.token;
+      const from = token ? token.span.start : cursorOffset;
+      const to = token ? token.span.end : cursorOffset;
+
+      return {
+        from,
+        to,
+        options: result.items.map(mapCompletionItem),
+        validFor: IDENTIFIER_CONTINUATION,
+      };
+    } catch (error) {
+      if (requestId !== requestCounter) {
+        return null;
+      }
+      onError?.(error);
+      return null;
+    }
+  };
+}

--- a/packages/react/src/completion/sqlCompletionSource.ts
+++ b/packages/react/src/completion/sqlCompletionSource.ts
@@ -21,6 +21,20 @@ export interface SqlCompletionSourceOptions {
   onError?: (error: unknown) => void;
 }
 
+function reportCompletionError(error: unknown, onError?: (error: unknown) => void): void {
+  if (onError) {
+    onError(error);
+    return;
+  }
+
+  // Log only the message to avoid dumping the full error (which may embed
+  // SQL/schema fragments) into shared consoles.
+  console.warn(
+    '[FlowScope] SQL completion failed:',
+    error instanceof Error ? error.message : String(error)
+  );
+}
+
 /** Re-query only while the user is still typing within a single identifier. */
 const IDENTIFIER_CONTINUATION = /^[\w$]*$/;
 const REPLACEABLE_TOKEN_KINDS = new Set(['identifier', 'keyword']);
@@ -99,7 +113,7 @@ export function createSqlCompletionSource(
       if (requestId !== requestCounter) {
         return null;
       }
-      onError?.(error);
+      reportCompletionError(error, onError);
       return null;
     }
   };

--- a/packages/react/src/completion/sqlCompletionSource.ts
+++ b/packages/react/src/completion/sqlCompletionSource.ts
@@ -3,7 +3,12 @@ import type {
   CompletionResult,
   CompletionSource,
 } from '@codemirror/autocomplete';
-import { completionItems, type Dialect, type SchemaMetadata } from '@pondpilot/flowscope-core';
+import {
+  completionItems,
+  type CompletionToken,
+  type Dialect,
+  type SchemaMetadata,
+} from '@pondpilot/flowscope-core';
 
 import { mapCompletionItem } from './mapCompletionItem';
 
@@ -18,6 +23,24 @@ export interface SqlCompletionSourceOptions {
 
 /** Re-query only while the user is still typing within a single identifier. */
 const IDENTIFIER_CONTINUATION = /^[\w$]*$/;
+const REPLACEABLE_TOKEN_KINDS = new Set(['identifier', 'keyword']);
+
+function resolveCompletionRange(
+  token: CompletionToken | undefined,
+  cursorOffset: number,
+  docLength: number
+): { from: number; to: number } {
+  const clamp = (offset: number) => Math.max(0, Math.min(docLength, offset));
+  const cursor = clamp(cursorOffset);
+
+  if (!token || !REPLACEABLE_TOKEN_KINDS.has(token.kind ?? '')) {
+    return { from: cursor, to: cursor };
+  }
+
+  const from = clamp(token.span.start);
+  const to = Math.max(from, clamp(token.span.end));
+  return { from, to };
+}
 
 /**
  * CodeMirror `CompletionSource` backed by flowscope's engine.
@@ -56,9 +79,15 @@ export function createSqlCompletionSource(
         return null;
       }
 
-      const token = result.token;
-      const from = token ? token.span.start : cursorOffset;
-      const to = token ? token.span.end : cursorOffset;
+      // Only replace the current token when the engine says the cursor is
+      // inside an identifier/keyword. Trigger characters like `.`, `(`, and
+      // `,` should stay in the document so qualified refs and function calls
+      // remain intact.
+      const { from, to } = resolveCompletionRange(
+        result.token,
+        cursorOffset,
+        context.state.doc.length
+      );
 
       return {
         from,

--- a/packages/react/src/components/LineageExplorer.tsx
+++ b/packages/react/src/components/LineageExplorer.tsx
@@ -10,12 +10,20 @@ interface LineageExplorerInnerProps {
   result: LineageExplorerProps['result'];
   sql: LineageExplorerProps['sql'];
   onSqlChange?: (sql: string) => void;
+  dialect?: LineageExplorerProps['dialect'];
+  completionSchema?: LineageExplorerProps['completionSchema'];
+  disableCompletion?: LineageExplorerProps['disableCompletion'];
+  onCompletionError?: LineageExplorerProps['onCompletionError'];
 }
 
 function LineageExplorerInner({
   result,
   sql,
   onSqlChange,
+  dialect,
+  completionSchema,
+  disableCompletion,
+  onCompletionError,
 }: LineageExplorerInnerProps): JSX.Element {
   const { actions } = useLineage();
 
@@ -31,7 +39,14 @@ function LineageExplorerInner({
     <div className="flowscope-explorer-inner">
       <div className="flowscope-main-layout">
         <div className="flowscope-left-panel">
-          <SqlView editable={!!onSqlChange} onChange={onSqlChange} />
+          <SqlView
+            editable={!!onSqlChange}
+            onChange={onSqlChange}
+            dialect={dialect}
+            completionSchema={completionSchema}
+            disableCompletion={disableCompletion}
+            onCompletionError={onCompletionError}
+          />
           <IssuesPanel />
         </div>
         <div className="flowscope-center-panel">
@@ -53,6 +68,10 @@ export function LineageExplorer({
   onSqlChange,
   theme = 'light',
   defaultLayoutAlgorithm,
+  dialect,
+  completionSchema,
+  disableCompletion,
+  onCompletionError,
 }: LineageExplorerProps): JSX.Element {
   const themeClass = theme === 'dark' ? 'dark' : '';
 
@@ -63,7 +82,15 @@ export function LineageExplorer({
       defaultLayoutAlgorithm={defaultLayoutAlgorithm}
     >
       <div className={`flowscope-explorer ${themeClass} ${className || ''}`.trim()}>
-        <LineageExplorerInner result={result} sql={sql} onSqlChange={onSqlChange} />
+        <LineageExplorerInner
+          result={result}
+          sql={sql}
+          onSqlChange={onSqlChange}
+          dialect={dialect}
+          completionSchema={completionSchema}
+          disableCompletion={disableCompletion}
+          onCompletionError={onCompletionError}
+        />
       </div>
     </LineageProvider>
   );

--- a/packages/react/src/components/SqlView.tsx
+++ b/packages/react/src/components/SqlView.tsx
@@ -3,7 +3,7 @@ import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { sql } from '@codemirror/lang-sql';
 import { acceptCompletion, autocompletion } from '@codemirror/autocomplete';
 import { EditorView, keymap, Decoration, type DecorationSet } from '@codemirror/view';
-import { StateField, StateEffect } from '@codemirror/state';
+import { Prec, StateField, StateEffect } from '@codemirror/state';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { charOffsetToByteOffset } from '@pondpilot/flowscope-core';
 
@@ -263,10 +263,11 @@ export function SqlView({
     });
     // `acceptCompletion` is a no-op (returns false) when no popup is open, so
     // binding Tab here leaves default Tab handling (indent / focus) intact
-    // outside of an active completion session.
+    // outside of an active completion session. `Prec.highest` ensures we win
+    // over basicSetup's `indentWithTab` binding while a popup is open.
     return [
       autocompletion({ override: [source] }),
-      keymap.of([{ key: 'Tab', run: acceptCompletion }]),
+      Prec.highest(keymap.of([{ key: 'Tab', run: acceptCompletion }])),
     ];
   }, [editable, disableCompletion]);
 

--- a/packages/react/src/components/SqlView.tsx
+++ b/packages/react/src/components/SqlView.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useCallback, useEffect, useRef, useState, type JSX } from 'react';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { sql } from '@codemirror/lang-sql';
-import { autocompletion } from '@codemirror/autocomplete';
-import { EditorView, Decoration, type DecorationSet } from '@codemirror/view';
+import { acceptCompletion, autocompletion } from '@codemirror/autocomplete';
+import { EditorView, keymap, Decoration, type DecorationSet } from '@codemirror/view';
 import { StateField, StateEffect } from '@codemirror/state';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { charOffsetToByteOffset } from '@pondpilot/flowscope-core';
@@ -261,7 +261,13 @@ export function SqlView({
         console.warn('FlowScope SQL completion failed:', error);
       },
     });
-    return autocompletion({ override: [source] });
+    // `acceptCompletion` is a no-op (returns false) when no popup is open, so
+    // binding Tab here leaves default Tab handling (indent / focus) intact
+    // outside of an active completion session.
+    return [
+      autocompletion({ override: [source] }),
+      keymap.of([{ key: 'Tab', run: acceptCompletion }]),
+    ];
   }, [editable, disableCompletion]);
 
   const extensions = useMemo(
@@ -272,7 +278,7 @@ export function SqlView({
       EditorView.lineWrapping,
       EditorView.editable.of(editable),
       selectionListener,
-      ...(completionExtension ? [completionExtension] : []),
+      ...(completionExtension ?? []),
     ],
     [editable, selectionListener, completionExtension]
   );

--- a/packages/react/src/components/SqlView.tsx
+++ b/packages/react/src/components/SqlView.tsx
@@ -1,12 +1,14 @@
 import { useMemo, useCallback, useEffect, useRef, useState, type JSX } from 'react';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { sql } from '@codemirror/lang-sql';
+import { autocompletion } from '@codemirror/autocomplete';
 import { EditorView, Decoration, type DecorationSet } from '@codemirror/view';
 import { StateField, StateEffect } from '@codemirror/state';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { charOffsetToByteOffset } from '@pondpilot/flowscope-core';
 
 import { useLineage, useLineageStore } from '../store';
+import { createSqlCompletionSource } from '../completion';
 import type { SqlViewProps } from '../types';
 import { trySpanToCharRange } from '../utils/sqlSpans';
 import {
@@ -72,6 +74,9 @@ export function SqlView({
   isDark,
   highlightedSpan: highlightedSpanProp,
   analyzedSourceName,
+  dialect,
+  completionSchema,
+  disableCompletion = false,
 }: SqlViewProps): JSX.Element {
   const { state, actions } = useLineage();
   const revealNodeInGraph = useLineageStore((store) => store.revealNodeInGraph);
@@ -236,6 +241,29 @@ export function SqlView({
     [computeRevealCandidate, handleReveal]
   );
 
+  // Mirror dialect/schema into refs so the completion source reads the latest
+  // values without requiring a CodeMirror reconfigure on every change.
+  const dialectRef = useRef(dialect);
+  const schemaRef = useRef(completionSchema);
+  useEffect(() => {
+    dialectRef.current = dialect;
+  }, [dialect]);
+  useEffect(() => {
+    schemaRef.current = completionSchema;
+  }, [completionSchema]);
+
+  const completionExtension = useMemo(() => {
+    if (!editable || disableCompletion) return null;
+    const source = createSqlCompletionSource({
+      getDialect: () => dialectRef.current ?? 'generic',
+      getSchema: () => schemaRef.current,
+      onError: (error) => {
+        console.warn('FlowScope SQL completion failed:', error);
+      },
+    });
+    return autocompletion({ override: [source] });
+  }, [editable, disableCompletion]);
+
   const extensions = useMemo(
     () => [
       sql(),
@@ -244,8 +272,9 @@ export function SqlView({
       EditorView.lineWrapping,
       EditorView.editable.of(editable),
       selectionListener,
+      ...(completionExtension ? [completionExtension] : []),
     ],
-    [editable, selectionListener]
+    [editable, selectionListener, completionExtension]
   );
 
   const theme = useMemo(() => (isDark ? oneDark : 'light'), [isDark]);

--- a/packages/react/src/components/SqlView.tsx
+++ b/packages/react/src/components/SqlView.tsx
@@ -77,6 +77,7 @@ export function SqlView({
   dialect,
   completionSchema,
   disableCompletion = false,
+  onCompletionError,
 }: SqlViewProps): JSX.Element {
   const { state, actions } = useLineage();
   const revealNodeInGraph = useLineageStore((store) => store.revealNodeInGraph);
@@ -241,16 +242,22 @@ export function SqlView({
     [computeRevealCandidate, handleReveal]
   );
 
-  // Mirror dialect/schema into refs so the completion source reads the latest
-  // values without requiring a CodeMirror reconfigure on every change.
+  // Mirror dialect/schema/onError into refs so the completion source reads the
+  // latest values without requiring a CodeMirror reconfigure on every change.
+  // That is also why these refs are intentionally *not* listed as deps of the
+  // memoized completion extension below.
   const dialectRef = useRef(dialect);
   const schemaRef = useRef(completionSchema);
+  const onCompletionErrorRef = useRef(onCompletionError);
   useEffect(() => {
     dialectRef.current = dialect;
   }, [dialect]);
   useEffect(() => {
     schemaRef.current = completionSchema;
   }, [completionSchema]);
+  useEffect(() => {
+    onCompletionErrorRef.current = onCompletionError;
+  }, [onCompletionError]);
 
   const completionExtension = useMemo(() => {
     if (!editable || disableCompletion) return null;
@@ -258,7 +265,17 @@ export function SqlView({
       getDialect: () => dialectRef.current ?? 'generic',
       getSchema: () => schemaRef.current,
       onError: (error) => {
-        console.warn('FlowScope SQL completion failed:', error);
+        const handler = onCompletionErrorRef.current;
+        if (handler) {
+          handler(error);
+          return;
+        }
+        // Log only the message to avoid dumping the full error (which may
+        // embed SQL/schema fragments) into shared consoles.
+        console.warn(
+          '[FlowScope] SQL completion failed:',
+          error instanceof Error ? error.message : String(error)
+        );
       },
     });
     // `acceptCompletion` is a no-op (returns false) when no popup is open, so

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -106,3 +106,7 @@ export type { ApplyTableFilterResult } from './utils/graphTraversal';
 
 // Stale-graph tracking
 export { computeStalePaths } from './utils/staleContent';
+
+// Completion
+export { createSqlCompletionSource, mapCompletionItem } from './completion';
+export type { SqlCompletionSourceOptions } from './completion';

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -6,6 +6,8 @@ import type {
   Issue,
   Span,
   SchemaTable,
+  SchemaMetadata,
+  Dialect,
   FilterPredicate,
   AggregationInfo,
 } from '@pondpilot/flowscope-core';
@@ -302,6 +304,21 @@ export interface SqlViewProps {
   highlightedSpan?: Span | null;
   /** Source file currently shown in controlled mode; used to scope reveal lookups safely */
   analyzedSourceName?: string;
+  /**
+   * SQL dialect used when the built-in completion source is active. Defaults
+   * to `'generic'`. Only consulted while `editable` is true.
+   */
+  dialect?: Dialect;
+  /**
+   * Schema catalog forwarded to the completion engine for column resolution.
+   * Optional; omit when no catalog is available.
+   */
+  completionSchema?: SchemaMetadata;
+  /**
+   * Disable the built-in SQL completion source. Defaults to `false`.
+   * Useful when the embedder wants to supply its own completion extension.
+   */
+  disableCompletion?: boolean;
 }
 
 /**

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -319,6 +319,12 @@ export interface SqlViewProps {
    * Useful when the embedder wants to supply its own completion extension.
    */
   disableCompletion?: boolean;
+  /**
+   * Callback invoked when the completion engine throws. If omitted, errors
+   * are logged via `console.warn` with only the message (no full error
+   * object) to avoid leaking SQL/schema details into shared consoles.
+   */
+  onCompletionError?: (error: unknown) => void;
 }
 
 /**
@@ -355,6 +361,14 @@ export interface LineageExplorerProps {
   theme?: 'light' | 'dark';
   /** Preferred default layout algorithm when the explorer first renders */
   defaultLayoutAlgorithm?: LayoutAlgorithm;
+  /** SQL dialect used by the built-in completion source in editable mode. */
+  dialect?: Dialect;
+  /** Optional schema catalog forwarded to the built-in completion source. */
+  completionSchema?: SchemaMetadata;
+  /** Disable the built-in SQL completion source in the embedded editor. */
+  disableCompletion?: boolean;
+  /** Optional hook invoked when the built-in completion source throws. */
+  onCompletionError?: (error: unknown) => void;
 }
 
 /**

--- a/packages/react/tests/mapCompletionItem.test.ts
+++ b/packages/react/tests/mapCompletionItem.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { CompletionItem } from '@pondpilot/flowscope-core';
+
+import { mapCompletionItem } from '../src/completion/mapCompletionItem';
+
+function item(overrides: Partial<CompletionItem>): CompletionItem {
+  return {
+    label: 'SELECT',
+    insertText: 'SELECT',
+    kind: 'keyword',
+    category: 'keyword',
+    score: 500,
+    clauseSpecific: false,
+    ...overrides,
+  };
+}
+
+describe('mapCompletionItem', () => {
+  it('maps each engine kind to a stable CodeMirror type', () => {
+    const kinds = [
+      ['keyword', 'keyword'],
+      ['operator', 'keyword'],
+      ['function', 'function'],
+      ['snippet', 'text'],
+      ['table', 'class'],
+      ['schemaTable', 'class'],
+      ['column', 'property'],
+    ] as const;
+
+    for (const [kind, expectedType] of kinds) {
+      expect(mapCompletionItem(item({ kind, category: kind })).type).toBe(expectedType);
+    }
+  });
+
+  it('passes through engine-supplied detail text verbatim', () => {
+    const result = mapCompletionItem(item({ kind: 'function', detail: 'COUNT(expr) → BIGINT' }));
+    expect(result.detail).toBe('COUNT(expr) → BIGINT');
+  });
+
+  it('falls back to a human-readable kind label when detail is missing', () => {
+    expect(mapCompletionItem(item({ kind: 'schemaTable' })).detail).toBe('schema table');
+    expect(mapCompletionItem(item({ kind: 'column' })).detail).toBe('column');
+  });
+
+  it('scales engine score into CodeMirror boost so ordering is preserved', () => {
+    const a = mapCompletionItem(item({ score: 900 }));
+    const b = mapCompletionItem(item({ score: 100 }));
+    expect((a.boost ?? 0) > (b.boost ?? 0)).toBe(true);
+  });
+
+  it('omits apply when insertText equals label so CodeMirror inserts the label directly', () => {
+    const result = mapCompletionItem(item({ label: 'SELECT', insertText: 'SELECT' }));
+    expect(result.apply).toBeUndefined();
+  });
+
+  it('uses insertText as apply when it diverges from the label', () => {
+    const result = mapCompletionItem(
+      item({ kind: 'function', label: 'COUNT', insertText: 'COUNT()' })
+    );
+    expect(result.apply).toBe('COUNT()');
+  });
+});

--- a/packages/react/tests/sqlCompletionSource.test.ts
+++ b/packages/react/tests/sqlCompletionSource.test.ts
@@ -169,6 +169,21 @@ describe('createSqlCompletionSource', () => {
     expect(onError).toHaveBeenCalledWith(error);
   });
 
+  it('treats in-band engine errors as failures and forwards them to onError', async () => {
+    completionItemsMock.mockResolvedValue(
+      engineResult({ shouldShow: false, items: [], error: 'SQL exceeds maximum length' })
+    );
+    const onError = vi.fn();
+    const source = createSqlCompletionSource({ onError });
+
+    const result = await source(contextAt('SELECT ', 7));
+
+    expect(result).toBeNull();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((onError.mock.calls[0][0] as Error).message).toBe('SQL exceeds maximum length');
+  });
+
   it('logs a warning when the engine throws and no onError hook is supplied', async () => {
     const error = new Error('engine blew up');
     completionItemsMock.mockRejectedValue(error);

--- a/packages/react/tests/sqlCompletionSource.test.ts
+++ b/packages/react/tests/sqlCompletionSource.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { CompletionContext } from '@codemirror/autocomplete';
+import type { CompletionItemsResult } from '@pondpilot/flowscope-core';
+
+const { completionItemsMock } = vi.hoisted(() => ({ completionItemsMock: vi.fn() }));
+
+vi.mock('@pondpilot/flowscope-core', async () => {
+  const actual = await vi.importActual<typeof import('@pondpilot/flowscope-core')>(
+    '@pondpilot/flowscope-core'
+  );
+  return {
+    ...actual,
+    completionItems: completionItemsMock,
+  };
+});
+
+import { createSqlCompletionSource } from '../src/completion/sqlCompletionSource';
+
+function contextAt(doc: string, pos: number): CompletionContext {
+  return new CompletionContext(EditorState.create({ doc }), pos, true);
+}
+
+function engineResult(overrides: Partial<CompletionItemsResult> = {}): CompletionItemsResult {
+  return {
+    clause: 'select',
+    shouldShow: true,
+    items: [
+      {
+        label: 'users',
+        insertText: 'users',
+        kind: 'table',
+        category: 'table',
+        score: 900,
+        clauseSpecific: true,
+      },
+    ],
+    token: { value: 'us', kind: 'identifier', span: { start: 7, end: 9 } },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  completionItemsMock.mockReset();
+});
+
+describe('createSqlCompletionSource', () => {
+  it('forwards CodeMirror char offsets to the engine using UTF-16 encoding', async () => {
+    completionItemsMock.mockResolvedValue(engineResult());
+    const source = createSqlCompletionSource({ getDialect: () => 'postgres' });
+
+    await source(contextAt('SELECT us', 9));
+
+    expect(completionItemsMock).toHaveBeenCalledWith({
+      sql: 'SELECT us',
+      dialect: 'postgres',
+      cursorOffset: 9,
+      schema: undefined,
+      encoding: 'utf16',
+    });
+  });
+
+  it("uses the engine's token span as the replace range so inserted text overwrites the partial identifier", async () => {
+    completionItemsMock.mockResolvedValue(engineResult());
+    const source = createSqlCompletionSource();
+
+    const result = await source(contextAt('SELECT us', 9));
+
+    expect(result).not.toBeNull();
+    expect(result!.from).toBe(7);
+    expect(result!.to).toBe(9);
+    expect(result!.options.map((o) => o.label)).toEqual(['users']);
+  });
+
+  it('returns null when the engine reports shouldShow=false', async () => {
+    completionItemsMock.mockResolvedValue(engineResult({ shouldShow: false }));
+    const source = createSqlCompletionSource();
+
+    const result = await source(contextAt('SELECT ', 7));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the engine produces no items', async () => {
+    completionItemsMock.mockResolvedValue(engineResult({ items: [] }));
+    const source = createSqlCompletionSource();
+
+    const result = await source(contextAt('SELECT ', 7));
+    expect(result).toBeNull();
+  });
+
+  it('defaults to the generic dialect when no accessor is provided', async () => {
+    completionItemsMock.mockResolvedValue(engineResult());
+    const source = createSqlCompletionSource();
+
+    await source(contextAt('SELECT ', 7));
+
+    expect(completionItemsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dialect: 'generic' })
+    );
+  });
+
+  it('drops stale results when a newer request starts before the previous resolves', async () => {
+    let resolveFirst!: (value: CompletionItemsResult) => void;
+    const firstPromise = new Promise<CompletionItemsResult>((resolve) => {
+      resolveFirst = resolve;
+    });
+    completionItemsMock.mockImplementationOnce(() => firstPromise);
+    completionItemsMock.mockResolvedValueOnce(engineResult());
+
+    const source = createSqlCompletionSource();
+    const firstCall = source(contextAt('SELECT u', 8));
+    // Start a second request before the first resolves — the first's eventual
+    // result is now stale and should be suppressed.
+    const secondCall = source(contextAt('SELECT us', 9));
+
+    resolveFirst(engineResult({ items: [] })); // Different payload, must be ignored.
+
+    expect(await firstCall).toBeNull();
+    expect(await secondCall).not.toBeNull();
+  });
+
+  it('swallows engine errors and forwards them to onError instead of throwing', async () => {
+    const error = new Error('engine blew up');
+    completionItemsMock.mockRejectedValue(error);
+    const onError = vi.fn();
+    const source = createSqlCompletionSource({ onError });
+
+    const result = await source(contextAt('SELECT ', 7));
+
+    expect(result).toBeNull();
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/react/tests/sqlCompletionSource.test.ts
+++ b/packages/react/tests/sqlCompletionSource.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EditorState } from '@codemirror/state';
 import { CompletionContext } from '@codemirror/autocomplete';
 import type { CompletionItemsResult } from '@pondpilot/flowscope-core';
@@ -42,6 +42,10 @@ function engineResult(overrides: Partial<CompletionItemsResult> = {}): Completio
 
 beforeEach(() => {
   completionItemsMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('createSqlCompletionSource', () => {
@@ -163,5 +167,18 @@ describe('createSqlCompletionSource', () => {
 
     expect(result).toBeNull();
     expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  it('logs a warning when the engine throws and no onError hook is supplied', async () => {
+    const error = new Error('engine blew up');
+    completionItemsMock.mockRejectedValue(error);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const source = createSqlCompletionSource();
+
+    const result = await source(contextAt('SELECT ', 7));
+
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledWith('[FlowScope] SQL completion failed:', 'engine blew up');
+    warn.mockRestore();
   });
 });

--- a/packages/react/tests/sqlCompletionSource.test.ts
+++ b/packages/react/tests/sqlCompletionSource.test.ts
@@ -72,6 +72,21 @@ describe('createSqlCompletionSource', () => {
     expect(result!.options.map((o) => o.label)).toEqual(['users']);
   });
 
+  it('keeps trigger punctuation in place by not replacing symbol tokens', async () => {
+    completionItemsMock.mockResolvedValue(
+      engineResult({
+        token: { value: '.', kind: 'symbol', span: { start: 10, end: 11 } },
+      })
+    );
+    const source = createSqlCompletionSource();
+
+    const result = await source(contextAt('SELECT cte.', 11));
+
+    expect(result).not.toBeNull();
+    expect(result!.from).toBe(11);
+    expect(result!.to).toBe(11);
+  });
+
   it('returns null when the engine reports shouldShow=false', async () => {
     completionItemsMock.mockResolvedValue(engineResult({ shouldShow: false }));
     const source = createSqlCompletionSource();
@@ -117,6 +132,25 @@ describe('createSqlCompletionSource', () => {
 
     expect(await firstCall).toBeNull();
     expect(await secondCall).not.toBeNull();
+  });
+
+  it('clamps an out-of-range token span to the document length', async () => {
+    // Simulate a stale / buggy engine response whose token span extends
+    // beyond the current document. We expect the source to clamp rather than
+    // hand CodeMirror invalid offsets.
+    const doc = 'SELECT us';
+    completionItemsMock.mockResolvedValue(
+      engineResult({
+        token: { value: 'us', kind: 'identifier', span: { start: 7, end: 9999 } },
+      })
+    );
+    const source = createSqlCompletionSource();
+
+    const result = await source(contextAt(doc, doc.length));
+
+    expect(result).not.toBeNull();
+    expect(result!.from).toBe(7);
+    expect(result!.to).toBe(doc.length);
   });
 
   it('swallows engine errors and forwards them to onError instead of throwing', async () => {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -60,6 +60,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show lineage info on hover"
+        },
+        "flowscope.enableCompletion": {
+          "type": "boolean",
+          "default": true,
+          "description": "Suggest dialect keywords, built-in functions, and node names as you type"
         }
       }
     },

--- a/vscode/src/analysis.ts
+++ b/vscode/src/analysis.ts
@@ -1,5 +1,11 @@
 import * as path from 'path';
-import type { AnalyzeRequest, AnalyzeResult, Dialect } from './types';
+import type {
+  AnalyzeRequest,
+  AnalyzeResult,
+  CompletionItemsResult,
+  CompletionRequest,
+  Dialect,
+} from './types';
 
 // WASM module - loaded lazily
 let wasmModule: typeof import('../wasm-node/flowscope_wasm') | null = null;
@@ -58,6 +64,23 @@ export function analyzeSql(request: AnalyzeRequest): AnalyzeResult {
  */
 export function analyzeSimple(sql: string, dialect: Dialect = 'generic'): AnalyzeResult {
   return analyzeSql({ sql, dialect });
+}
+
+/**
+ * Compute context-aware SQL completion candidates at `cursorOffset`.
+ *
+ * Returns the full response from the flowscope completion engine: dialect
+ * keywords, built-in functions, operators, and any node names (tables,
+ * views, CTEs, columns) surfaced from the current parse.
+ */
+export function completionItems(request: CompletionRequest): CompletionItemsResult {
+  if (!wasmModule) {
+    throw new Error('WASM not initialized. Call initWasm() first.');
+  }
+
+  const requestJson = JSON.stringify(request);
+  const resultJson = wasmModule.completion_items_json(requestJson);
+  return JSON.parse(resultJson) as CompletionItemsResult;
 }
 
 /**

--- a/vscode/src/analysis.ts
+++ b/vscode/src/analysis.ts
@@ -26,11 +26,12 @@ export async function initWasm(extensionPath: string): Promise<void> {
   try {
     // Use dynamic require for the WASM module
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    wasmModule = require(wasmNodePath);
+    const loadedWasmModule = require(wasmNodePath) as typeof import('../wasm-node/flowscope_wasm');
+    wasmModule = loadedWasmModule;
 
     // Install panic hook for better error messages
-    if (wasmModule.set_panic_hook) {
-      wasmModule.set_panic_hook();
+    if (loadedWasmModule.set_panic_hook) {
+      loadedWasmModule.set_panic_hook();
     }
   } catch (error) {
     throw new Error(

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -3,6 +3,7 @@ import { initWasm, isWasmInitialized, getEngineVersion } from './analysis';
 import { FlowScopeCodeLensProvider } from './providers/codeLens';
 import { FlowScopeHoverProvider } from './providers/hover';
 import { FlowScopeDiagnosticsProvider } from './providers/diagnostics';
+import { FlowScopeCompletionProvider } from './providers/completion';
 import { LineagePanel } from './webview/lineagePanel';
 
 let diagnosticsProvider: FlowScopeDiagnosticsProvider | undefined;
@@ -37,6 +38,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Register Diagnostics provider
   diagnosticsProvider = new FlowScopeDiagnosticsProvider();
   context.subscriptions.push(diagnosticsProvider);
+
+  // Register Completion provider
+  const completionProvider = new FlowScopeCompletionProvider();
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      { language: 'sql' },
+      completionProvider,
+      ...FlowScopeCompletionProvider.triggerCharacters
+    )
+  );
 
   // Register commands
   context.subscriptions.push(

--- a/vscode/src/providers/completion.ts
+++ b/vscode/src/providers/completion.ts
@@ -1,0 +1,109 @@
+import * as vscode from 'vscode';
+import { completionItems, isWasmInitialized } from '../analysis';
+import type { CompletionItem as FlowscopeCompletionItem, Dialect } from '../types';
+
+/**
+ * Provides SQL IntelliSense backed by the flowscope completion engine:
+ * dialect keywords, built-in functions, operators, and any table / view /
+ * CTE / column names recovered from the current parse.
+ */
+export class FlowScopeCompletionProvider implements vscode.CompletionItemProvider {
+  /** Completions fire on every typed character, plus `.` for qualified refs. */
+  public static readonly triggerCharacters: readonly string[] = ['.'];
+
+  public provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    _token: vscode.CancellationToken,
+    _context: vscode.CompletionContext
+  ): vscode.ProviderResult<vscode.CompletionList> {
+    const config = vscode.workspace.getConfiguration('flowscope');
+    if (!config.get<boolean>('enableCompletion', true)) {
+      return null;
+    }
+
+    if (!isWasmInitialized()) {
+      return null;
+    }
+
+    const sql = document.getText();
+    const dialect = config.get<Dialect>('dialect', 'generic');
+    // `document.offsetAt` yields a UTF-16 code-unit offset, which matches
+    // `encoding: 'utf16'` on the engine request — no byte conversion needed.
+    const cursorOffset = document.offsetAt(position);
+
+    let result;
+    try {
+      result = completionItems({ sql, dialect, cursorOffset, encoding: 'utf16' });
+    } catch (error) {
+      console.warn('FlowScope completion failed:', error);
+      return null;
+    }
+
+    if (!result.shouldShow || result.items.length === 0) {
+      return null;
+    }
+
+    const replaceRange = result.token
+      ? new vscode.Range(
+          document.positionAt(result.token.span.start),
+          document.positionAt(result.token.span.end)
+        )
+      : undefined;
+
+    return new vscode.CompletionList(
+      result.items.map((item) => toVsCodeCompletionItem(item, replaceRange)),
+      /* isIncomplete */ false
+    );
+  }
+}
+
+const VSCODE_KIND_BY_FLOWSCOPE_KIND: Record<
+  FlowscopeCompletionItem['kind'],
+  vscode.CompletionItemKind
+> = {
+  keyword: vscode.CompletionItemKind.Keyword,
+  operator: vscode.CompletionItemKind.Operator,
+  function: vscode.CompletionItemKind.Function,
+  snippet: vscode.CompletionItemKind.Snippet,
+  table: vscode.CompletionItemKind.Struct,
+  schemaTable: vscode.CompletionItemKind.Module,
+  column: vscode.CompletionItemKind.Field,
+};
+
+const FALLBACK_DETAIL: Record<FlowscopeCompletionItem['kind'], string> = {
+  keyword: 'keyword',
+  operator: 'operator',
+  function: 'function',
+  snippet: 'snippet',
+  table: 'table',
+  schemaTable: 'schema table',
+  column: 'column',
+};
+
+/**
+ * VS Code sorts completions by `sortText` ascending. The flowscope engine
+ * returns higher scores for better matches, so we invert the score to keep
+ * the order the user expects.
+ */
+const MAX_SORT_BUCKET = 9999;
+
+function toVsCodeCompletionItem(
+  item: FlowscopeCompletionItem,
+  replaceRange: vscode.Range | undefined
+): vscode.CompletionItem {
+  const completion = new vscode.CompletionItem(
+    item.label,
+    VSCODE_KIND_BY_FLOWSCOPE_KIND[item.kind]
+  );
+  completion.detail = item.detail ?? FALLBACK_DETAIL[item.kind];
+  if (item.insertText !== item.label) {
+    completion.insertText = item.insertText;
+  }
+  if (replaceRange) {
+    completion.range = replaceRange;
+  }
+  const bucket = Math.max(0, Math.min(MAX_SORT_BUCKET, Math.floor(MAX_SORT_BUCKET - item.score)));
+  completion.sortText = bucket.toString().padStart(5, '0') + item.label.toLowerCase();
+  return completion;
+}

--- a/vscode/src/providers/completion.ts
+++ b/vscode/src/providers/completion.ts
@@ -66,6 +66,11 @@ export class FlowScopeCompletionProvider implements vscode.CompletionItemProvide
       return null;
     }
 
+    if (result.error) {
+      console.warn('[FlowScope] completion failed:', result.error);
+      return null;
+    }
+
     if (!result.shouldShow || result.items.length === 0) {
       return null;
     }

--- a/vscode/src/providers/completion.ts
+++ b/vscode/src/providers/completion.ts
@@ -8,15 +8,23 @@ import type { CompletionItem as FlowscopeCompletionItem, Dialect } from '../type
  * CTE / column names recovered from the current parse.
  */
 export class FlowScopeCompletionProvider implements vscode.CompletionItemProvider {
-  /** Completions fire on every typed character, plus `.` for qualified refs. */
+  /**
+   * `.` auto-triggers completion for qualified refs. Typing alphabetic
+   * characters relies on VS Code's default behavior (manual invocation with
+   * Ctrl+Space, or re-query while a completion list is already open).
+   */
   public static readonly triggerCharacters: readonly string[] = ['.'];
 
   public provideCompletionItems(
     document: vscode.TextDocument,
     position: vscode.Position,
-    _token: vscode.CancellationToken,
+    token: vscode.CancellationToken,
     _context: vscode.CompletionContext
   ): vscode.ProviderResult<vscode.CompletionList> {
+    if (token.isCancellationRequested) {
+      return null;
+    }
+
     const config = vscode.workspace.getConfiguration('flowscope');
     if (!config.get<boolean>('enableCompletion', true)) {
       return null;
@@ -27,16 +35,27 @@ export class FlowScopeCompletionProvider implements vscode.CompletionItemProvide
     }
 
     const sql = document.getText();
-    const dialect = config.get<Dialect>('dialect', 'generic');
+    const dialect = resolveDialect(config);
     // `document.offsetAt` yields a UTF-16 code-unit offset, which matches
     // `encoding: 'utf16'` on the engine request — no byte conversion needed.
     const cursorOffset = document.offsetAt(position);
+
+    if (token.isCancellationRequested) {
+      return null;
+    }
 
     let result;
     try {
       result = completionItems({ sql, dialect, cursorOffset, encoding: 'utf16' });
     } catch (error) {
-      console.warn('FlowScope completion failed:', error);
+      console.warn(
+        '[FlowScope] completion failed:',
+        error instanceof Error ? error.message : String(error)
+      );
+      return null;
+    }
+
+    if (token.isCancellationRequested) {
       return null;
     }
 
@@ -44,18 +63,53 @@ export class FlowScopeCompletionProvider implements vscode.CompletionItemProvide
       return null;
     }
 
-    const replaceRange = result.token
-      ? new vscode.Range(
-          document.positionAt(result.token.span.start),
-          document.positionAt(result.token.span.end)
-        )
-      : undefined;
+    const replaceRange = resolveReplaceRange(document, result.token);
 
     return new vscode.CompletionList(
       result.items.map((item) => toVsCodeCompletionItem(item, replaceRange)),
       /* isIncomplete */ false
     );
   }
+}
+
+function resolveReplaceRange(
+  document: vscode.TextDocument,
+  token: { kind?: string; span: { start: number; end: number } } | undefined
+): vscode.Range | undefined {
+  if (!token || (token.kind !== 'identifier' && token.kind !== 'keyword')) {
+    return undefined;
+  }
+
+  const docLength = document.getText().length;
+  const clamp = (offset: number) => Math.max(0, Math.min(docLength, offset));
+  const from = clamp(token.span.start);
+  const to = Math.max(from, clamp(token.span.end));
+  return new vscode.Range(document.positionAt(from), document.positionAt(to));
+}
+
+const VALID_DIALECTS: readonly Dialect[] = [
+  'generic',
+  'ansi',
+  'bigquery',
+  'clickhouse',
+  'databricks',
+  'duckdb',
+  'hive',
+  'mssql',
+  'mysql',
+  'postgres',
+  'redshift',
+  'snowflake',
+  'sqlite',
+];
+
+function resolveDialect(config: vscode.WorkspaceConfiguration): Dialect {
+  const raw = config.get<string>('dialect', 'generic');
+  if ((VALID_DIALECTS as readonly string[]).includes(raw)) {
+    return raw as Dialect;
+  }
+  console.warn(`[FlowScope] unknown dialect "${raw}" in settings; falling back to "generic".`);
+  return 'generic';
 }
 
 const VSCODE_KIND_BY_FLOWSCOPE_KIND: Record<

--- a/vscode/src/providers/completion.ts
+++ b/vscode/src/providers/completion.ts
@@ -7,13 +7,20 @@ import type { CompletionItem as FlowscopeCompletionItem, Dialect } from '../type
  * dialect keywords, built-in functions, operators, and any table / view /
  * CTE / column names recovered from the current parse.
  */
+const IDENTIFIER_TRIGGER_CHARACTERS = [
+  '.',
+  '_',
+  '$',
+  ...'abcdefghijklmnopqrstuvwxyz',
+  ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+] as const;
+
 export class FlowScopeCompletionProvider implements vscode.CompletionItemProvider {
   /**
-   * `.` auto-triggers completion for qualified refs. Typing alphabetic
-   * characters relies on VS Code's default behavior (manual invocation with
-   * Ctrl+Space, or re-query while a completion list is already open).
+   * Trigger on identifier characters so keyword/function/table suggestions
+   * appear while the user types, not only after manual invocation or `.`.
    */
-  public static readonly triggerCharacters: readonly string[] = ['.'];
+  public static readonly triggerCharacters: readonly string[] = IDENTIFIER_TRIGGER_CHARACTERS;
 
   public provideCompletionItems(
     document: vscode.TextDocument,

--- a/vscode/src/types.ts
+++ b/vscode/src/types.ts
@@ -149,6 +149,74 @@ export interface IssueCount {
   infos: number;
 }
 
+export type Encoding = 'utf8' | 'utf16';
+
+export interface CompletionRequest {
+  sql: string;
+  dialect: Dialect;
+  cursorOffset: number;
+  encoding?: Encoding;
+}
+
+export type CompletionClause =
+  | 'select'
+  | 'from'
+  | 'where'
+  | 'join'
+  | 'on'
+  | 'groupBy'
+  | 'having'
+  | 'orderBy'
+  | 'limit'
+  | 'qualify'
+  | 'window'
+  | 'insert'
+  | 'update'
+  | 'delete'
+  | 'with'
+  | 'unknown';
+
+export type CompletionTokenKind =
+  | 'keyword'
+  | 'identifier'
+  | 'literal'
+  | 'operator'
+  | 'symbol'
+  | 'unknown';
+
+export interface CompletionToken {
+  value: string;
+  kind: CompletionTokenKind;
+  span: Span;
+}
+
+export type CompletionItemKind =
+  | 'keyword'
+  | 'operator'
+  | 'function'
+  | 'snippet'
+  | 'table'
+  | 'column'
+  | 'schemaTable';
+
+export interface CompletionItem {
+  label: string;
+  insertText: string;
+  kind: CompletionItemKind;
+  category: string;
+  score: number;
+  clauseSpecific: boolean;
+  detail?: string;
+}
+
+export interface CompletionItemsResult {
+  clause: CompletionClause;
+  token?: CompletionToken;
+  shouldShow: boolean;
+  items: CompletionItem[];
+  error?: string;
+}
+
 /**
  * Return the nodes from an `AnalyzeResult` that participate in the given
  * statement index. Uses the flat `result.nodes` collection; matching is


### PR DESCRIPTION
### Summary

Adds SQL IntelliSense to both the React `SqlView` (CodeMirror 6) and the VS Code extension, backed by flowscope's existing `completion_items_json` WASM entry point. Typing in an editable SQL surface now surfaces dialect keywords, built-in functions, operators, and any table / CTE / column names recovered from the current parse.

Closes #26.

### What's in the box

**React package — `packages/react/src/completion/`**

- `sqlCompletionSource.ts` — `CompletionSource` factory. Reads full document + UTF-16 cursor offset from the `CompletionContext`, calls `completionItems({ encoding: 'utf16', … })`, maps the result to a CodeMirror `CompletionResult` using the engine's token span for the replace range and `validFor: /^[\w$]*$/` so CM filters locally while the user keeps typing the same identifier.
- `mapCompletionItem.ts` — pure `CompletionItem → Completion` mapper. Kind → CM type (table → `class`, column → `property`, …), score rescaled by 100 for CM's `boost`, `apply` populated only when `insertText` diverges from `label`.
- Stale-request handling via a monotonic counter so a slow engine call never overwrites the result of a newer keystroke.
- Engine errors go to an optional `onError` callback; the source never throws into CM.

**SqlView props**

- `dialect?: Dialect`, `completionSchema?: SchemaMetadata`, `disableCompletion?: boolean`.
- Dialect / schema are read through refs so changing them doesn't force a CodeMirror reconfigure.
- Tab binding added at `Prec.highest` — `acceptCompletion` wins over `basicSetup`'s `indentWithTab` when the popup is open and falls through to indent otherwise.

**App wiring**

- `EditorArea` passes `currentProject.dialect` through to `SqlView`.

**VS Code extension — `vscode/src/providers/completion.ts`**

- `FlowScopeCompletionProvider` implementing `vscode.CompletionItemProvider`, registered for `language: 'sql'` with `.` as an extra trigger character.
- `document.offsetAt(position)` for UTF-16 cursor offsets; same `encoding: 'utf16'` pattern as the React side, so no byte conversion.
- Completion kinds → `vscode.CompletionItemKind` (table → `Struct`, schemaTable → `Module`, column → `Field`, …). Engine `score` is inverted into a zero-padded `sortText` bucket so higher scores sort first.
- Gated by new `flowscope.enableCompletion` setting (default on).

**Types**

- The extension currently duplicates core types; added `CompletionRequest`, `CompletionItemsResult`, `CompletionItem`, `CompletionClause`, `CompletionToken`, and related enums to `vscode/src/types.ts` to match `@pondpilot/flowscope-core`.

### What's intentionally not here

- **Dialect-specific keywords in the Rust engine.** The TOML specs exist but aren't wired into the completion context yet. Filing a follow-up; it affects completeness for non-DuckDB dialects but not the shape of this PR.
- **`alias.column` semantic resolver UI** (#27). The engine already populates `columns_in_scope`, so columns flow through naturally, but the dedicated dot-trigger UX designed in #27 is still open.

### Test plan

- [x] `yarn workspace @pondpilot/flowscope-react test` — 182 passing (13 new: 6 for `mapCompletionItem`, 7 for `sqlCompletionSource` covering UTF-16 offset forwarding, token → replace-range, `shouldShow` gating, default-dialect fallback, stale-request dropping, and error isolation).
- [x] `just typecheck` — clean.
- [x] `just lint-ts` — clean.
- [x] Manual: typed `WITH user_cohort AS (SELECT user_id FROM users) SELECT * FROM u` in the demo app, confirmed popup surfaces `user_cohort`, `users`, `user_id`, dialect keywords (`UNION`, `USING`, `UNNEST`, `UPDATE`), and matching functions.
- [x] Manual: Tab accepts the highlighted suggestion with the popup open; Tab still indents when it's closed.
- [ ] VS Code side exercised in Extension Development Host (reviewer please verify; test infra in `vscode/` is thin so this wasn't automated).
