### PR TITLE
fix(lineage): unify dbt model producer and consumer nodes (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Core Engine (flowscope-core)
+- **dbt multi-model chains now render as connected lineage** ([#32](https://github.com/pondpilot/flowscope/issues/32)) — a dbt model's bare SELECT is materialized as the canonical Table node for the model name instead of a per-statement Output node, so when a downstream file references it via `{{ ref(...) }}` the producer and consumer collapse into a single graph node and multi-hop `A -> B -> C` pipelines show end-to-end.
+
 ## [0.6.0] - 2026-03-22
 
 ### Added

--- a/app/src/lib/analysis-hash.ts
+++ b/app/src/lib/analysis-hash.ts
@@ -4,7 +4,11 @@ import type { TemplateMode } from '@/types';
 // Bump when analyzer semantics change so persisted IndexedDB results
 // do not replay stale graphs across app reloads.
 // v4: relation-to-column edges for source-less projections (COUNT(*), SELECT 1)
-const HASH_VERSION = 'v4';
+// v5: flattened AnalyzeResult (top-level nodes/edges) + dbt multi-model lineage
+//     (dbtModelSink metadata, definition occurrences, ephemeral model sinks).
+//     Required: pre-flatten entries stored with v4 keys would rehydrate without
+//     top-level `result.nodes`, crashing consumers like useSearchSuggestions.
+const HASH_VERSION = 'v5';
 const FNV_OFFSET_BASIS = 0xcbf29ce484222325n;
 const FNV_PRIME = 0x100000001b3n;
 const FNV_MASK = 0xffffffffffffffffn;

--- a/crates/flowscope-core/src/analyzer.rs
+++ b/crates/flowscope-core/src/analyzer.rs
@@ -495,8 +495,12 @@ impl<'a> Analyzer<'a> {
     /// `produced_views`.
     ///
     /// Two other responsibilities handled here:
-    /// - Detecting duplicate model names across files (silent last-writer-wins
-    ///   would otherwise mask real project configuration errors).
+    /// - Detecting duplicate model names across files and surfacing a warning
+    ///   so real project configuration errors aren't silently masked. The
+    ///   first definition's materialization wins for node identity; later
+    ///   producer statements still overwrite the producer index via the
+    ///   normal `record_produced` path, so cross-statement edges point at the
+    ///   most recently seen producer.
     /// - Surfacing a warning when `materialized=` is present but can't be
     ///   resolved (dynamic Jinja or adapter-specific value), so users know
     ///   we fell back to the default node type.
@@ -528,7 +532,7 @@ impl<'a> Analyzer<'a> {
                     Issue::warning(
                         issue_codes::SCHEMA_CONFLICT,
                         format!(
-                            "Duplicate dbt model '{model_name}' defined in multiple files ('{existing}' and '{source_name}'); later definition wins"
+                            "Duplicate dbt model '{model_name}' defined in multiple files: first in '{existing}', then in '{source_name}'. Keeping the materialization from '{existing}'; the later file's producer statement will still claim the producer index."
                         ),
                     )
                     .with_statement(index),

--- a/crates/flowscope-core/src/analyzer.rs
+++ b/crates/flowscope-core/src/analyzer.rs
@@ -314,6 +314,8 @@ impl<'a> Analyzer<'a> {
                 source_name,
                 source_sql,
                 source_range,
+                source_sql_untemplated,
+                source_range_untemplated,
                 templating_applied,
                 ..
             },
@@ -334,6 +336,11 @@ impl<'a> Analyzer<'a> {
             } else {
                 None
             };
+            let original_sql = source_sql_untemplated.as_deref().and_then(|sql| {
+                source_range_untemplated
+                    .as_ref()
+                    .and_then(|range| sql.get(range.clone()).map(str::to_string))
+            });
             self.current_statement_source = Some(StatementSourceSlice {
                 sql: source_sql,
                 range: source_range.clone(),
@@ -345,6 +352,8 @@ impl<'a> Analyzer<'a> {
                 &statement,
                 source_name_owned,
                 source_range,
+                source_range_untemplated,
+                original_sql,
                 resolved_sql,
             );
             self.current_statement_source = None;

--- a/crates/flowscope-core/src/analyzer.rs
+++ b/crates/flowscope-core/src/analyzer.rs
@@ -39,7 +39,7 @@ use helpers::{
 };
 use input::{collect_statements, StatementInput};
 use schema_registry::SchemaRegistry;
-use statements::{dbt_model_relation_type, extract_model_name};
+use statements::{dbt_model_relation_type, extract_model_name, StatementSource};
 use std::collections::HashMap;
 
 // Re-export for use in other analyzer modules
@@ -352,10 +352,12 @@ impl<'a> Analyzer<'a> {
                 index,
                 &statement,
                 source_name_owned,
-                source_range,
-                source_range_untemplated,
-                original_sql,
-                resolved_sql,
+                StatementSource {
+                    source_range,
+                    original_source_range: source_range_untemplated,
+                    original_sql,
+                    resolved_sql,
+                },
             );
             self.current_statement_source = None;
 
@@ -480,7 +482,7 @@ impl<'a> Analyzer<'a> {
     }
 
     fn precollect_dbt_models(&mut self, statements: &[StatementInput]) {
-        for stmt_input in statements {
+        for (index, stmt_input) in statements.iter().enumerate() {
             let Statement::Query(_) = &stmt_input.statement else {
                 continue;
             };
@@ -498,12 +500,12 @@ impl<'a> Analyzer<'a> {
                         .as_ref()
                         .and_then(|range| sql.get(range.clone()))
                 });
-            if dbt_model_relation_type(original_sql) != NodeType::View {
-                continue;
-            }
-
             let model_name = self.normalize_table_name(extract_model_name(source_name));
-            self.tracker.declare_view(&model_name);
+            if dbt_model_relation_type(original_sql) == NodeType::View {
+                self.tracker.record_view_produced(&model_name, index);
+            } else {
+                self.tracker.record_produced(&model_name, index);
+            }
         }
     }
 

--- a/crates/flowscope-core/src/analyzer.rs
+++ b/crates/flowscope-core/src/analyzer.rs
@@ -39,6 +39,7 @@ use helpers::{
 };
 use input::{collect_statements, StatementInput};
 use schema_registry::SchemaRegistry;
+use statements::{dbt_model_relation_type, extract_model_name};
 use std::collections::HashMap;
 
 // Re-export for use in other analyzer modules
@@ -461,6 +462,10 @@ impl<'a> Analyzer<'a> {
     fn precollect_ddl(&mut self, statements: &[StatementInput]) {
         self.descriptions = self.collect_description_map(statements);
 
+        if self.is_dbt_mode() {
+            self.precollect_dbt_models(statements);
+        }
+
         for (index, stmt_input) in statements.iter().enumerate() {
             match &stmt_input.statement {
                 Statement::CreateTable(create) => {
@@ -471,6 +476,34 @@ impl<'a> Analyzer<'a> {
                 }
                 _ => {}
             }
+        }
+    }
+
+    fn precollect_dbt_models(&mut self, statements: &[StatementInput]) {
+        for stmt_input in statements {
+            let Statement::Query(_) = &stmt_input.statement else {
+                continue;
+            };
+
+            let Some(source_name) = stmt_input.source_name.as_deref() else {
+                continue;
+            };
+
+            let original_sql = stmt_input
+                .source_sql_untemplated
+                .as_deref()
+                .and_then(|sql| {
+                    stmt_input
+                        .source_range_untemplated
+                        .as_ref()
+                        .and_then(|range| sql.get(range.clone()))
+                });
+            if dbt_model_relation_type(original_sql) != NodeType::View {
+                continue;
+            }
+
+            let model_name = self.normalize_table_name(extract_model_name(source_name));
+            self.tracker.declare_view(&model_name);
         }
     }
 

--- a/crates/flowscope-core/src/analyzer.rs
+++ b/crates/flowscope-core/src/analyzer.rs
@@ -39,7 +39,10 @@ use helpers::{
 };
 use input::{collect_statements, StatementInput};
 use schema_registry::SchemaRegistry;
-use statements::{dbt_model_relation_type, extract_model_name, StatementSource};
+use statements::{
+    detect_dbt_model_materialization, extract_model_name, DbtMaterializationDetection,
+    StatementSource,
+};
 use std::collections::HashMap;
 
 // Re-export for use in other analyzer modules
@@ -481,7 +484,25 @@ impl<'a> Analyzer<'a> {
         }
     }
 
+    /// Pre-registers dbt model relations so forward `ref(...)` consumers and
+    /// later producers share one canonical node identity.
+    ///
+    /// This pass only **declares type** — it does not record a producer
+    /// statement index. Producer indices are set later by the main analysis
+    /// pass via `record_view_produced` / `record_produced`. Keeping that
+    /// single source of truth for production avoids duplicating producer
+    /// state and prevents `declared_views` from drifting out of sync with
+    /// `produced_views`.
+    ///
+    /// Two other responsibilities handled here:
+    /// - Detecting duplicate model names across files (silent last-writer-wins
+    ///   would otherwise mask real project configuration errors).
+    /// - Surfacing a warning when `materialized=` is present but can't be
+    ///   resolved (dynamic Jinja or adapter-specific value), so users know
+    ///   we fell back to the default node type.
     fn precollect_dbt_models(&mut self, statements: &[StatementInput]) {
+        let mut first_source: HashMap<String, String> = HashMap::new();
+
         for (index, stmt_input) in statements.iter().enumerate() {
             let Statement::Query(_) = &stmt_input.statement else {
                 continue;
@@ -501,10 +522,49 @@ impl<'a> Analyzer<'a> {
                         .and_then(|range| sql.get(range.clone()))
                 });
             let model_name = self.normalize_table_name(extract_model_name(source_name));
-            if dbt_model_relation_type(original_sql) == NodeType::View {
-                self.tracker.record_view_produced(&model_name, index);
-            } else {
-                self.tracker.record_produced(&model_name, index);
+
+            if let Some(existing) = first_source.get(&model_name) {
+                self.issues.push(
+                    Issue::warning(
+                        issue_codes::SCHEMA_CONFLICT,
+                        format!(
+                            "Duplicate dbt model '{model_name}' defined in multiple files ('{existing}' and '{source_name}'); later definition wins"
+                        ),
+                    )
+                    .with_statement(index),
+                );
+                continue;
+            }
+            first_source.insert(model_name.clone(), source_name.to_string());
+
+            let detection = original_sql
+                .map(detect_dbt_model_materialization)
+                .unwrap_or(DbtMaterializationDetection::NotConfigured);
+
+            match detection.node_type() {
+                Some(NodeType::View) => self.tracker.declare_view(&model_name),
+                Some(NodeType::Cte) => self.tracker.declare_ephemeral(&model_name),
+                // Table is the default in `relation_identity`, but we still
+                // need to declare it so forward `ref(...)` consumers resolve
+                // to a known relation instead of emitting
+                // `UNRESOLVED_REFERENCE` before the producer statement runs.
+                // `None` (NotConfigured / Unresolved) also defaults to table.
+                Some(NodeType::Table) | None => self.tracker.declare_table(&model_name),
+                Some(NodeType::Output | NodeType::Column) => {
+                    unreachable!("dbt materializations must map to relation-like node types")
+                }
+            }
+
+            if matches!(detection, DbtMaterializationDetection::Unresolved) {
+                self.issues.push(
+                    Issue::warning(
+                        issue_codes::APPROXIMATE_LINEAGE,
+                        format!(
+                            "dbt model '{model_name}' has a dynamic or unsupported `materialized` value; defaulting to table"
+                        ),
+                    )
+                    .with_statement(index),
+                );
             }
         }
     }

--- a/crates/flowscope-core/src/analyzer.rs
+++ b/crates/flowscope-core/src/analyzer.rs
@@ -532,7 +532,7 @@ impl<'a> Analyzer<'a> {
                     Issue::warning(
                         issue_codes::SCHEMA_CONFLICT,
                         format!(
-                            "Duplicate dbt model '{model_name}' defined in multiple files: first in '{existing}', then in '{source_name}'. Keeping the materialization from '{existing}'; the later file's producer statement will still claim the producer index."
+                            "Duplicate dbt model '{model_name}' defined in both '{existing}' and '{source_name}'. Node identity (table/view/ephemeral) is taken from the first definition ('{existing}'); cross-statement lineage edges still point to the last statement that produces the model."
                         ),
                     )
                     .with_statement(index),

--- a/crates/flowscope-core/src/analyzer/context.rs
+++ b/crates/flowscope-core/src/analyzer/context.rs
@@ -445,6 +445,40 @@ impl StatementContext {
         node_id
     }
 
+    /// Creates or returns the sink node for a dbt model's bare SELECT.
+    ///
+    /// Unlike `ensure_output_node_with_model`, which synthesizes a
+    /// statement-scoped `Output` node, this materializes the sink as a
+    /// relation node (`Table`/`View`) whose id is the canonical relation id
+    /// shared with consumers. When another dbt model references this one via
+    /// `FROM {{ ref(...) }}`, its `Table` node resolves to the same canonical
+    /// id, so the flattener merges producer and consumer into a single graph
+    /// node and multi-hop `A -> B -> C` chains render as one connected
+    /// lineage rather than disconnected per-file fragments.
+    pub(crate) fn ensure_model_relation_sink(
+        &mut self,
+        model_name: &str,
+        canonical_id: Arc<str>,
+        node_type: NodeType,
+    ) -> Arc<str> {
+        if let Some(existing) = self.output_node_id.as_ref() {
+            return existing.clone();
+        }
+
+        let label: Arc<str> = Arc::from(model_name);
+        let sink_node = Node {
+            id: canonical_id.clone(),
+            node_type,
+            label: label.clone(),
+            qualified_name: Some(label),
+            ..Default::default()
+        };
+
+        self.add_node(sink_node);
+        self.output_node_id = Some(canonical_id.clone());
+        canonical_id
+    }
+
     pub(crate) fn output_node_id(&self) -> Option<&Arc<str>> {
         self.output_node_id.as_ref()
     }

--- a/crates/flowscope-core/src/analyzer/context.rs
+++ b/crates/flowscope-core/src/analyzer/context.rs
@@ -3,6 +3,8 @@ use crate::types::{Edge, FilterClauseType, FilterPredicate, JoinType, Node, Node
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+pub(crate) const DBT_MODEL_SINK_METADATA_KEY: &str = "dbtModelSink";
+
 /// Tracks a SELECT * that couldn't be expanded due to missing schema.
 ///
 /// When a wildcard is encountered without schema metadata to resolve it,
@@ -477,6 +479,10 @@ impl StatementContext {
         let label: Arc<str> = Arc::from(model_name);
         let mut metadata = HashMap::new();
         metadata.insert("definitionOccurrence".to_string(), serde_json::json!(true));
+        metadata.insert(
+            DBT_MODEL_SINK_METADATA_KEY.to_string(),
+            serde_json::json!(true),
+        );
         let sink_node = Node {
             id: canonical_id.clone(),
             node_type,

--- a/crates/flowscope-core/src/analyzer/context.rs
+++ b/crates/flowscope-core/src/analyzer/context.rs
@@ -157,7 +157,7 @@ pub(crate) struct StatementContext {
     ///   canonical id here is what lets downstream `ref(...)` consumers
     ///   merge onto the same node, so multi-hop dbt chains render as one
     ///   connected graph instead of per-file fragments.
-    pub(crate) output_node_id: Option<Arc<str>>,
+    pub(crate) sink_node_id: Option<Arc<str>>,
     /// Statement-global output columns for named CTE definitions.
     /// Scope-local alias materialization lives on [`Scope::subquery_columns`] so reused
     /// aliases do not leak across sibling branches or nested scopes.
@@ -234,7 +234,7 @@ impl StatementContext {
             current_join_info: JoinInfo::default(),
             table_node_ids: HashMap::new(),
             output_columns: Vec::new(),
-            output_node_id: None,
+            sink_node_id: None,
             aliased_subquery_columns: HashMap::new(),
             scope_stack: Vec::new(),
             next_scope_id: 0,
@@ -428,7 +428,7 @@ impl StatementContext {
     /// will use the model name as both its label and qualified_name. This
     /// enables proper cross-statement linking for dbt model references.
     pub(crate) fn ensure_output_node_with_model(&mut self, model_name: Option<&str>) -> Arc<str> {
-        if let Some(existing) = self.output_node_id.as_ref() {
+        if let Some(existing) = self.sink_node_id.as_ref() {
             return existing.clone();
         }
 
@@ -449,7 +449,7 @@ impl StatementContext {
         };
 
         self.add_node(output_node);
-        self.output_node_id = Some(node_id.clone());
+        self.sink_node_id = Some(node_id.clone());
         node_id
     }
 
@@ -470,7 +470,7 @@ impl StatementContext {
         node_type: NodeType,
         span: Option<Span>,
     ) -> Arc<str> {
-        if let Some(existing) = self.output_node_id.as_ref() {
+        if let Some(existing) = self.sink_node_id.as_ref() {
             return existing.clone();
         }
 
@@ -485,12 +485,12 @@ impl StatementContext {
         };
 
         self.add_node(sink_node);
-        self.output_node_id = Some(canonical_id.clone());
+        self.sink_node_id = Some(canonical_id.clone());
         canonical_id
     }
 
-    pub(crate) fn output_node_id(&self) -> Option<&Arc<str>> {
-        self.output_node_id.as_ref()
+    pub(crate) fn sink_node_id(&self) -> Option<&Arc<str>> {
+        self.sink_node_id.as_ref()
     }
 
     /// Push a new scope onto the stack (entering a SELECT/subquery)

--- a/crates/flowscope-core/src/analyzer/context.rs
+++ b/crates/flowscope-core/src/analyzer/context.rs
@@ -1,5 +1,5 @@
 use super::helpers::generate_output_node_id;
-use crate::types::{Edge, FilterClauseType, FilterPredicate, JoinType, Node, NodeType};
+use crate::types::{Edge, FilterClauseType, FilterPredicate, JoinType, Node, NodeType, Span};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -460,6 +460,7 @@ impl StatementContext {
         model_name: &str,
         canonical_id: Arc<str>,
         node_type: NodeType,
+        span: Option<Span>,
     ) -> Arc<str> {
         if let Some(existing) = self.output_node_id.as_ref() {
             return existing.clone();
@@ -471,6 +472,7 @@ impl StatementContext {
             node_type,
             label: label.clone(),
             qualified_name: Some(label),
+            span,
             ..Default::default()
         };
 

--- a/crates/flowscope-core/src/analyzer/context.rs
+++ b/crates/flowscope-core/src/analyzer/context.rs
@@ -456,10 +456,10 @@ impl StatementContext {
     /// Creates or returns the sink node for a dbt model's bare SELECT.
     ///
     /// Unlike `ensure_output_node_with_model`, which synthesizes a
-    /// statement-scoped `Output` node, this materializes the sink as a
-    /// relation node (`Table`/`View`) whose id is the canonical relation id
-    /// shared with consumers. When another dbt model references this one via
-    /// `FROM {{ ref(...) }}`, its `Table` node resolves to the same canonical
+    /// statement-scoped `Output` node, this materializes the sink as the
+    /// canonical shared model node (`Table`, `View`, or `Cte` for ephemeral
+    /// dbt models). When another dbt model references this one via
+    /// `FROM {{ ref(...) }}`, its source node resolves to the same canonical
     /// id, so the flattener merges producer and consumer into a single graph
     /// node and multi-hop `A -> B -> C` chains render as one connected
     /// lineage rather than disconnected per-file fragments.
@@ -475,12 +475,15 @@ impl StatementContext {
         }
 
         let label: Arc<str> = Arc::from(model_name);
+        let mut metadata = HashMap::new();
+        metadata.insert("definitionOccurrence".to_string(), serde_json::json!(true));
         let sink_node = Node {
             id: canonical_id.clone(),
             node_type,
             label: label.clone(),
             qualified_name: Some(label),
             span,
+            metadata: Some(metadata),
             ..Default::default()
         };
 
@@ -489,6 +492,15 @@ impl StatementContext {
         canonical_id
     }
 
+    /// Returns the id of this statement's sink, if one has been materialized.
+    ///
+    /// The sink represents "where this statement writes". Callers must not
+    /// assume it is always a statement-scoped `Output` node — for dbt models
+    /// it is the canonical relation node (`Table` / `View` / `Cte`) created
+    /// by [`Self::ensure_model_relation_sink`], which is the same node that
+    /// downstream `ref(...)` consumers resolve to. Treat the returned id as
+    /// opaque and look up the node's `node_type` if behavior needs to branch
+    /// on the sink's kind.
     pub(crate) fn sink_node_id(&self) -> Option<&Arc<str>> {
         self.sink_node_id.as_ref()
     }

--- a/crates/flowscope-core/src/analyzer/context.rs
+++ b/crates/flowscope-core/src/analyzer/context.rs
@@ -148,7 +148,15 @@ pub(crate) struct StatementContext {
     pub(crate) table_node_ids: HashMap<String, Arc<str>>,
     /// Output columns for this statement (for column lineage)
     pub(crate) output_columns: Vec<OutputColumn>,
-    /// Output node ID for SELECT statements
+    /// Id of this statement's sink node. Holds one of two shapes:
+    ///
+    /// - A statement-scoped `Output` node id, produced by
+    ///   [`Self::ensure_output_node_with_model`] for standalone SELECTs.
+    /// - A canonical relation id (Table/View), produced by
+    ///   [`Self::ensure_model_relation_sink`] for dbt models. Using the
+    ///   canonical id here is what lets downstream `ref(...)` consumers
+    ///   merge onto the same node, so multi-hop dbt chains render as one
+    ///   connected graph instead of per-file fragments.
     pub(crate) output_node_id: Option<Arc<str>>,
     /// Statement-global output columns for named CTE definitions.
     /// Scope-local alias materialization lives on [`Scope::subquery_columns`] so reused

--- a/crates/flowscope-core/src/analyzer/cross_statement.rs
+++ b/crates/flowscope-core/src/analyzer/cross_statement.rs
@@ -184,9 +184,15 @@ impl CrossStatementTracker {
     ///
     /// Views are tracked separately to ensure correct node type in lineage graphs.
     /// This also calls `record_produced` internally.
+    ///
+    /// Upholds the declared-set disjointness invariant: if the canonical name
+    /// had been pre-declared as a table (e.g. via [`declare_table`] before an
+    /// override), the table declaration is removed so `is_declared` /
+    /// `relation_identity` don't observe the name in both sets at once.
     pub(crate) fn record_view_produced(&mut self, canonical: &str, statement_index: usize) {
         self.produced_views.insert(canonical.to_string());
         self.declared_views.insert(canonical.to_string());
+        self.declared_tables.remove(canonical);
         self.record_produced(canonical, statement_index);
     }
 

--- a/crates/flowscope-core/src/analyzer/cross_statement.rs
+++ b/crates/flowscope-core/src/analyzer/cross_statement.rs
@@ -56,6 +56,45 @@ use super::helpers::generate_node_id;
 /// - Cross-statement edges are only created when consumer index > producer index
 /// - `all_relations` contains the union of all produced and consumed tables
 ///
+/// ## Declaration vs production
+///
+/// "Declaration" and "production" are distinct concepts, populated by
+/// different passes:
+///
+/// - *Declaration* (`declared_views` / `declared_tables` /
+///   `declared_ephemerals`) fixes a relation's **identity** — i.e. whether it
+///   resolves as a `view_*` / `table_*` / `cte_*` node id via
+///   [`CrossStatementTracker::relation_identity`]. It is populated up-front by
+///   pre-collection passes (e.g. dbt models) so forward `ref(...)` consumers
+///   resolve to the same canonical node as the later producer.
+/// - *Production* (`produced_tables` / `produced_views`) assigns a **producer
+///   statement index** used for cross-statement edge generation. It is
+///   populated during the main analysis pass as each producing statement is
+///   visited.
+///
+/// A relation can be declared without ever being produced (e.g. the producer
+/// statement is skipped) and a relation can be produced without prior
+/// declaration (standard CREATE TABLE flow). Both state spaces coexist and
+/// must stay consistent.
+///
+/// ## Declared-set disjointness
+///
+/// The three declared sets are mutually exclusive for any single canonical
+/// name, because a relation has exactly one materialization kind:
+///
+/// - View declarations take precedence over table declarations: calling
+///   [`CrossStatementTracker::declare_view`] removes the name from
+///   `declared_tables`, and [`CrossStatementTracker::declare_table`] is a
+///   no-op when the name is already in `declared_views` (view is strictly
+///   more specific).
+/// - `declared_ephemerals` is treated independently (dbt ephemeral models
+///   never materialize as tables or views), and relation identity is resolved
+///   in the order ephemeral → view → table in
+///   [`CrossStatementTracker::relation_identity`].
+///
+/// Keep these rules in mind when adding new declaration paths; violating them
+/// would make [`CrossStatementTracker::relation_identity`] non-deterministic.
+///
 /// # Example
 ///
 /// ```ignore

--- a/crates/flowscope-core/src/analyzer/cross_statement.rs
+++ b/crates/flowscope-core/src/analyzer/cross_statement.rs
@@ -136,6 +136,7 @@ impl CrossStatementTracker {
 
     /// Records that a relation is known to materialize as a view before the
     /// producer statement is analyzed.
+    #[cfg(test)]
     pub(crate) fn declare_view(&mut self, canonical: &str) {
         self.declared_views.insert(canonical.to_string());
         self.all_relations.insert(canonical.to_string());

--- a/crates/flowscope-core/src/analyzer/cross_statement.rs
+++ b/crates/flowscope-core/src/analyzer/cross_statement.rs
@@ -87,6 +87,21 @@ pub(crate) struct CrossStatementTracker {
     /// references resolved earlier in the workload still get the canonical
     /// `view_*` identity and merge with the later producer sink.
     pub(crate) declared_views: HashSet<String>,
+    /// Canonical names that are known to materialize as physical tables even
+    /// before the producing statement is analyzed.
+    ///
+    /// Populated alongside [`declared_views`] during pre-collection so that
+    /// forward `ref(...)` consumers resolve to a known relation instead of
+    /// emitting a false `UNRESOLVED_REFERENCE` warning. The producer's
+    /// statement index is still assigned later by the main analysis pass via
+    /// [`record_produced`].
+    pub(crate) declared_tables: HashSet<String>,
+    /// Canonical names that are known to materialize as dbt ephemeral models.
+    ///
+    /// Ephemeral models behave like cross-file CTEs rather than persisted
+    /// relations, so references to them should reuse a canonical `cte_*`
+    /// identity instead of fabricating a table/view node.
+    pub(crate) declared_ephemerals: HashSet<String>,
     /// Maps table canonical name -> list of statement indices that consume it.
     ///
     /// A single table can be consumed by multiple statements.
@@ -108,6 +123,8 @@ impl CrossStatementTracker {
             produced_tables: HashMap::new(),
             produced_views: HashSet::new(),
             declared_views: HashSet::new(),
+            declared_tables: HashSet::new(),
+            declared_ephemerals: HashSet::new(),
             consumed_tables: HashMap::new(),
             all_relations: HashSet::new(),
             all_ctes: HashSet::new(),
@@ -134,11 +151,44 @@ impl CrossStatementTracker {
         self.record_produced(canonical, statement_index);
     }
 
+    /// Records that a dbt model is known to materialize as `ephemeral`.
+    ///
+    /// Ephemeral models are inlined into downstream SQL rather than persisted
+    /// as relations, so we model them with a canonical CTE identity instead of
+    /// registering them as produced tables/views.
+    pub(crate) fn declare_ephemeral(&mut self, canonical: &str) {
+        self.declared_ephemerals.insert(canonical.to_string());
+        self.all_ctes.insert(canonical.to_string());
+    }
+
     /// Records that a relation is known to materialize as a view before the
     /// producer statement is analyzed.
-    #[cfg(test)]
+    ///
+    /// Used by precollection passes (e.g. dbt models) to fix a relation's
+    /// identity up front so earlier consumer references resolve to the same
+    /// canonical `view_*` id as the later producer. This intentionally does
+    /// **not** record a producer statement index — that still happens in the
+    /// main analysis pass via `record_view_produced` / `record_produced`.
     pub(crate) fn declare_view(&mut self, canonical: &str) {
         self.declared_views.insert(canonical.to_string());
+        self.declared_tables.remove(canonical);
+        self.all_relations.insert(canonical.to_string());
+    }
+
+    /// Records that a relation is known to materialize as a physical table
+    /// before the producer statement is analyzed.
+    ///
+    /// Mirrors [`declare_view`] for the table case: consumer references can
+    /// resolve to a known relation even when their statement runs before the
+    /// producer's. The producer's statement index is still set later by the
+    /// main analysis pass via [`record_produced`].
+    pub(crate) fn declare_table(&mut self, canonical: &str) {
+        // If the caller previously declared this name as a view, leave the
+        // view declaration in place — view is strictly more specific and the
+        // identity (`view_*` id) must win.
+        if !self.declared_views.contains(canonical) {
+            self.declared_tables.insert(canonical.to_string());
+        }
         self.all_relations.insert(canonical.to_string());
     }
 
@@ -171,12 +221,29 @@ impl CrossStatementTracker {
         self.produced_views.contains(canonical) || self.declared_views.contains(canonical)
     }
 
+    fn is_ephemeral_relation(&self, canonical: &str) -> bool {
+        self.declared_ephemerals.contains(canonical)
+    }
+
     /// Checks if a table was produced by an earlier statement.
     ///
     /// Used to determine if a table reference is to a locally-created table
     /// (as opposed to an external table from imported schema).
     pub(crate) fn was_produced(&self, canonical: &str) -> bool {
         self.produced_tables.contains_key(canonical)
+    }
+
+    /// Checks if a canonical name has been pre-declared (by a pass like
+    /// precollection) but not yet formally produced by its statement.
+    ///
+    /// This is the resolver's signal that "forward references to this
+    /// relation are expected — the producer will run later." Separate from
+    /// [`was_produced`] so callers that actually need a producer statement
+    /// index (e.g. cross-statement edge generation) stay strict.
+    pub(crate) fn is_declared(&self, canonical: &str) -> bool {
+        self.declared_views.contains(canonical)
+            || self.declared_tables.contains(canonical)
+            || self.declared_ephemerals.contains(canonical)
     }
 
     /// Gets the statement index that produced a table, if any.
@@ -193,14 +260,20 @@ impl CrossStatementTracker {
         self.produced_tables.remove(canonical);
         self.produced_views.remove(canonical);
         self.declared_views.remove(canonical);
+        self.declared_tables.remove(canonical);
+        self.declared_ephemerals.remove(canonical);
     }
 
-    /// Returns the correct node ID and type for a relation (view vs table).
+    /// Returns the correct node ID and type for a relation-like model sink.
     ///
-    /// Views get IDs prefixed with "view_", tables get "table_".
-    /// This ensures consistent node identification across the lineage graph.
+    /// Views get IDs prefixed with `view_`, tables with `table_`, and dbt
+    /// ephemeral models with `cte_`. This ensures consistent node
+    /// identification across the lineage graph without inventing persisted
+    /// relations for ephemeral models.
     pub(crate) fn relation_identity(&self, canonical: &str) -> (Arc<str>, NodeType) {
-        if self.is_view_relation(canonical) {
+        if self.is_ephemeral_relation(canonical) {
+            (generate_node_id("cte", canonical), NodeType::Cte)
+        } else if self.is_view_relation(canonical) {
             (generate_node_id("view", canonical), NodeType::View)
         } else {
             (generate_node_id("table", canonical), NodeType::Table)
@@ -236,7 +309,9 @@ impl CrossStatementTracker {
         }
 
         let instance_key = format!("{canonical}::{alias}::scope_{scope_id}");
-        if self.is_view_relation(canonical) {
+        if self.is_ephemeral_relation(canonical) {
+            (generate_node_id("cte", &instance_key), NodeType::Cte)
+        } else if self.is_view_relation(canonical) {
             (generate_node_id("view", &instance_key), NodeType::View)
         } else {
             (generate_node_id("table", &instance_key), NodeType::Table)
@@ -360,6 +435,17 @@ mod tests {
     }
 
     #[test]
+    fn test_declared_ephemeral_uses_cte_identity_before_producer_runs() {
+        let mut tracker = CrossStatementTracker::new();
+
+        tracker.declare_ephemeral("models.future_ephemeral");
+
+        let (node_id, node_type) = tracker.relation_identity("models.future_ephemeral");
+        assert!(node_id.starts_with("cte_"));
+        assert_eq!(node_type, NodeType::Cte);
+    }
+
+    #[test]
     fn test_cross_statement_edges() {
         let mut tracker = CrossStatementTracker::new();
 
@@ -475,6 +561,7 @@ mod tests {
         assert!(tracker.consumed_tables.is_empty());
         assert!(tracker.produced_views.is_empty());
         assert!(tracker.declared_views.is_empty());
+        assert!(tracker.declared_ephemerals.is_empty());
     }
 
     #[test]

--- a/crates/flowscope-core/src/analyzer/cross_statement.rs
+++ b/crates/flowscope-core/src/analyzer/cross_statement.rs
@@ -80,6 +80,13 @@ pub(crate) struct CrossStatementTracker {
     ///
     /// Used to determine node type (view vs table) for ID generation.
     pub(crate) produced_views: HashSet<String>,
+    /// Canonical names that are known to materialize as views even before the
+    /// producing statement is analyzed.
+    ///
+    /// This is populated during pre-collection for dbt models so consumer
+    /// references resolved earlier in the workload still get the canonical
+    /// `view_*` identity and merge with the later producer sink.
+    pub(crate) declared_views: HashSet<String>,
     /// Maps table canonical name -> list of statement indices that consume it.
     ///
     /// A single table can be consumed by multiple statements.
@@ -100,6 +107,7 @@ impl CrossStatementTracker {
         Self {
             produced_tables: HashMap::new(),
             produced_views: HashSet::new(),
+            declared_views: HashSet::new(),
             consumed_tables: HashMap::new(),
             all_relations: HashSet::new(),
             all_ctes: HashSet::new(),
@@ -122,7 +130,15 @@ impl CrossStatementTracker {
     /// This also calls `record_produced` internally.
     pub(crate) fn record_view_produced(&mut self, canonical: &str, statement_index: usize) {
         self.produced_views.insert(canonical.to_string());
+        self.declared_views.insert(canonical.to_string());
         self.record_produced(canonical, statement_index);
+    }
+
+    /// Records that a relation is known to materialize as a view before the
+    /// producer statement is analyzed.
+    pub(crate) fn declare_view(&mut self, canonical: &str) {
+        self.declared_views.insert(canonical.to_string());
+        self.all_relations.insert(canonical.to_string());
     }
 
     /// Records that a table was consumed by a statement.
@@ -147,7 +163,11 @@ impl CrossStatementTracker {
     /// Checks if a canonical name refers to a view.
     #[cfg(test)]
     pub(crate) fn is_view(&self, canonical: &str) -> bool {
-        self.produced_views.contains(canonical)
+        self.is_view_relation(canonical)
+    }
+
+    fn is_view_relation(&self, canonical: &str) -> bool {
+        self.produced_views.contains(canonical) || self.declared_views.contains(canonical)
     }
 
     /// Checks if a table was produced by an earlier statement.
@@ -171,6 +191,7 @@ impl CrossStatementTracker {
     pub(crate) fn remove(&mut self, canonical: &str) {
         self.produced_tables.remove(canonical);
         self.produced_views.remove(canonical);
+        self.declared_views.remove(canonical);
     }
 
     /// Returns the correct node ID and type for a relation (view vs table).
@@ -178,7 +199,7 @@ impl CrossStatementTracker {
     /// Views get IDs prefixed with "view_", tables get "table_".
     /// This ensures consistent node identification across the lineage graph.
     pub(crate) fn relation_identity(&self, canonical: &str) -> (Arc<str>, NodeType) {
-        if self.produced_views.contains(canonical) {
+        if self.is_view_relation(canonical) {
             (generate_node_id("view", canonical), NodeType::View)
         } else {
             (generate_node_id("table", canonical), NodeType::Table)
@@ -214,7 +235,7 @@ impl CrossStatementTracker {
         }
 
         let instance_key = format!("{canonical}::{alias}::scope_{scope_id}");
-        if self.produced_views.contains(canonical) {
+        if self.is_view_relation(canonical) {
             (generate_node_id("view", &instance_key), NodeType::View)
         } else {
             (generate_node_id("table", &instance_key), NodeType::Table)
@@ -321,6 +342,18 @@ mod tests {
         assert_eq!(table_type, NodeType::Table);
 
         let (view_id, view_type) = tracker.relation_identity("public.my_view");
+        assert!(view_id.starts_with("view_"));
+        assert_eq!(view_type, NodeType::View);
+    }
+
+    #[test]
+    fn test_declared_view_uses_view_identity_before_producer_runs() {
+        let mut tracker = CrossStatementTracker::new();
+
+        tracker.declare_view("models.future_view");
+
+        assert!(tracker.is_view("models.future_view"));
+        let (view_id, view_type) = tracker.relation_identity("models.future_view");
         assert!(view_id.starts_with("view_"));
         assert_eq!(view_type, NodeType::View);
     }
@@ -440,6 +473,7 @@ mod tests {
         assert!(tracker.produced_tables.is_empty());
         assert!(tracker.consumed_tables.is_empty());
         assert!(tracker.produced_views.is_empty());
+        assert!(tracker.declared_views.is_empty());
     }
 
     #[test]

--- a/crates/flowscope-core/src/analyzer/global.rs
+++ b/crates/flowscope-core/src/analyzer/global.rs
@@ -16,9 +16,13 @@ use tracing::debug;
 const OCCURRENCE_SPANS_METADATA_KEY: &str = "occurrenceSpans";
 const OCCURRENCE_STATEMENT_IDS_METADATA_KEY: &str = "occurrenceStatementIds";
 const OCCURRENCE_SOURCE_NAMES_METADATA_KEY: &str = "occurrenceSourceNames";
+const DEFINITION_OCCURRENCE_SPANS_METADATA_KEY: &str = "definitionOccurrenceSpans";
+const DEFINITION_OCCURRENCE_STATEMENT_IDS_METADATA_KEY: &str = "definitionOccurrenceStatementIds";
+const DEFINITION_OCCURRENCE_SOURCE_NAMES_METADATA_KEY: &str = "definitionOccurrenceSourceNames";
 const BODY_SPANS_METADATA_KEY: &str = "bodySpans";
 const BODY_STATEMENT_IDS_METADATA_KEY: &str = "bodyStatementIds";
 const BODY_SOURCE_NAMES_METADATA_KEY: &str = "bodySourceNames";
+const DEFINITION_OCCURRENCE_FLAG_METADATA_KEY: &str = "definitionOccurrence";
 
 impl<'a> Analyzer<'a> {
     pub(super) fn build_result(&self) -> crate::AnalyzeResult {
@@ -197,7 +201,8 @@ impl<'a> Analyzer<'a> {
         statement_index: usize,
         source_name: Option<&str>,
     ) {
-        for node in lineage_nodes {
+        for mut node in lineage_nodes {
+            let has_definition_occurrence = strip_definition_occurrence_flag(&mut node);
             let canonical = node
                 .qualified_name
                 .clone()
@@ -211,7 +216,13 @@ impl<'a> Analyzer<'a> {
 
             match state.flat_nodes.entry(global_id.clone()) {
                 std::collections::hash_map::Entry::Occupied(mut e) => {
-                    merge_node_into(e.get_mut(), node, statement_index, source_name);
+                    merge_node_into(
+                        e.get_mut(),
+                        node,
+                        statement_index,
+                        source_name,
+                        has_definition_occurrence,
+                    );
                 }
                 std::collections::hash_map::Entry::Vacant(slot) => {
                     let mut initial = Node {
@@ -224,6 +235,9 @@ impl<'a> Analyzer<'a> {
                     record_statement_aggregation(&mut initial, statement_index);
                     record_occurrences(&mut initial, statement_index, source_name);
                     record_body_span(&mut initial, statement_index, source_name);
+                    if has_definition_occurrence {
+                        record_definition_occurrences(&mut initial, statement_index, source_name);
+                    }
                     // name_spans / filters / resolution_source / aggregation
                     // all travel from the source node via the spread above.
                     normalize_name_spans(&mut initial);
@@ -553,12 +567,16 @@ fn merge_node_into(
     incoming: Node,
     statement_index: usize,
     source_name: Option<&str>,
+    has_definition_occurrence: bool,
 ) {
     let incoming_aggregation = incoming.aggregation.clone();
     record_statement_filters_from_slice(existing, statement_index, &incoming.filters);
     record_statement_aggregation_from_option(existing, statement_index, incoming_aggregation);
     record_occurrences_from_node(existing, &incoming, statement_index, source_name);
     record_body_span_from_node(existing, &incoming, statement_index, source_name);
+    if has_definition_occurrence {
+        record_definition_occurrences_from_node(existing, &incoming, statement_index, source_name);
+    }
 
     if !existing.statement_ids.contains(&statement_index) {
         existing.statement_ids.push(statement_index);
@@ -625,6 +643,15 @@ fn record_occurrences(node: &mut Node, statement_index: usize, source_name: Opti
     record_occurrences_from_node(node, &occurrence_source, statement_index, source_name);
 }
 
+fn record_definition_occurrences(
+    node: &mut Node,
+    statement_index: usize,
+    source_name: Option<&str>,
+) {
+    let occurrence_source = node.clone();
+    record_definition_occurrences_from_node(node, &occurrence_source, statement_index, source_name);
+}
+
 fn record_occurrences_from_node(
     node: &mut Node,
     occurrence_source: &Node,
@@ -639,41 +666,95 @@ fn record_occurrences_from_node(
     );
 }
 
+fn record_definition_occurrences_from_node(
+    node: &mut Node,
+    occurrence_source: &Node,
+    statement_index: usize,
+    source_name: Option<&str>,
+) {
+    append_occurrence_records_with_keys(
+        node,
+        &occurrence_source.all_name_spans(),
+        statement_index,
+        source_name,
+        DEFINITION_OCCURRENCE_SPANS_METADATA_KEY,
+        DEFINITION_OCCURRENCE_STATEMENT_IDS_METADATA_KEY,
+        DEFINITION_OCCURRENCE_SOURCE_NAMES_METADATA_KEY,
+    );
+}
+
 fn append_occurrence_records(
     node: &mut Node,
     spans: &[Span],
     statement_index: usize,
     source_name: Option<&str>,
 ) {
+    append_occurrence_records_with_keys(
+        node,
+        spans,
+        statement_index,
+        source_name,
+        OCCURRENCE_SPANS_METADATA_KEY,
+        OCCURRENCE_STATEMENT_IDS_METADATA_KEY,
+        OCCURRENCE_SOURCE_NAMES_METADATA_KEY,
+    );
+}
+
+fn append_occurrence_records_with_keys(
+    node: &mut Node,
+    spans: &[Span],
+    statement_index: usize,
+    source_name: Option<&str>,
+    spans_key: &str,
+    statement_ids_key: &str,
+    source_names_key: &str,
+) {
     if spans.is_empty() {
         return;
     }
 
     let metadata = node.metadata.get_or_insert_with(HashMap::new);
-    ensure_array(metadata, OCCURRENCE_SPANS_METADATA_KEY);
-    ensure_array(metadata, OCCURRENCE_STATEMENT_IDS_METADATA_KEY);
-    ensure_array(metadata, OCCURRENCE_SOURCE_NAMES_METADATA_KEY);
+    ensure_array(metadata, spans_key);
+    ensure_array(metadata, statement_ids_key);
+    ensure_array(metadata, source_names_key);
 
     for span in spans {
         append_to_array(
             metadata,
-            OCCURRENCE_SPANS_METADATA_KEY,
+            spans_key,
             serde_json::to_value(span).unwrap_or(Value::Null),
         );
         append_to_array(
             metadata,
-            OCCURRENCE_STATEMENT_IDS_METADATA_KEY,
+            statement_ids_key,
             Value::from(statement_index as u64),
         );
         append_to_array(
             metadata,
-            OCCURRENCE_SOURCE_NAMES_METADATA_KEY,
+            source_names_key,
             match source_name {
                 Some(value) => Value::String(value.to_string()),
                 None => Value::Null,
             },
         );
     }
+}
+
+fn strip_definition_occurrence_flag(node: &mut Node) -> bool {
+    let Some(metadata) = node.metadata.as_mut() else {
+        return false;
+    };
+
+    let is_definition = metadata
+        .remove(DEFINITION_OCCURRENCE_FLAG_METADATA_KEY)
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+
+    if metadata.is_empty() {
+        node.metadata = None;
+    }
+
+    is_definition
 }
 
 fn record_body_span(node: &mut Node, statement_index: usize, source_name: Option<&str>) {

--- a/crates/flowscope-core/src/analyzer/query.rs
+++ b/crates/flowscope-core/src/analyzer/query.rs
@@ -303,7 +303,8 @@ impl<'a> Analyzer<'a> {
             self.relation_identity(&canonical)
         };
 
-        let is_known = self.is_table_known(&canonical, resolution.matched_schema);
+        let is_known = node_type == NodeType::Cte
+            || self.is_table_known(&canonical, resolution.matched_schema);
         let resolution_source = self.determine_resolution_source(&canonical, is_known);
 
         // Create node if not already present
@@ -336,11 +337,15 @@ impl<'a> Analyzer<'a> {
     /// A table is known if any of:
     /// - `matched_schema`: Found in imported or implied schema
     /// - `produced`: Created by an earlier statement in the workload (CREATE TABLE, etc.)
+    /// - `declared`: Pre-registered by a precollection pass (e.g., a dbt model
+    ///   whose producer statement has not yet been analyzed). Forward `ref(...)`
+    ///   consumers need this so they don't misfire `UNRESOLVED_REFERENCE`.
     /// - No tables known at all: When we have zero knowledge, be permissive to avoid false warnings
     fn is_table_known(&self, canonical: &str, matched_schema: bool) -> bool {
         let produced = self.tracker.was_produced(canonical);
+        let declared = self.tracker.is_declared(canonical);
         let no_tables_known = self.schema.has_no_known_tables();
-        matched_schema || produced || no_tables_known
+        matched_schema || produced || declared || no_tables_known
     }
 
     /// Determines the resolution source for a table.

--- a/crates/flowscope-core/src/analyzer/statements.rs
+++ b/crates/flowscope-core/src/analyzer/statements.rs
@@ -66,14 +66,23 @@ impl<'a> Analyzer<'a> {
                 // Normalize the model name to match how table references are normalized
                 // (e.g., Snowflake normalizes to uppercase)
                 let normalized_model_name = model_name.map(|n| self.normalize_table_name(n));
-                ctx.ensure_output_node_with_model(normalized_model_name.as_deref());
 
-                // Register the model as a produced table for cross-statement linking
-                if let Some(ref name) = normalized_model_name {
+                let sink_target_id = if let Some(ref name) = normalized_model_name {
+                    // Register the model as a produced table so downstream files
+                    // that reference it via `ref(...)` see a known relation.
                     self.tracker.record_produced(name, index);
-                }
+                    // Materialize the sink as the canonical relation node so it
+                    // unifies with consumer FROM references sharing the same
+                    // canonical name (see issue #32).
+                    let (canonical_id, node_type) = self.tracker.relation_identity(name);
+                    let sink_id = ctx.ensure_model_relation_sink(name, canonical_id, node_type);
+                    Some(sink_id.to_string())
+                } else {
+                    ctx.ensure_output_node_with_model(None);
+                    None
+                };
 
-                self.analyze_query(&mut ctx, query, None);
+                self.analyze_query(&mut ctx, query, sink_target_id.as_deref());
                 classify_query_type(query)
             }
             Statement::Insert(insert) => {

--- a/crates/flowscope-core/src/analyzer/statements.rs
+++ b/crates/flowscope-core/src/analyzer/statements.rs
@@ -49,6 +49,8 @@ impl<'a> Analyzer<'a> {
         statement: &Statement,
         source_name: Option<String>,
         source_range: Range<usize>,
+        original_source_range: Option<Range<usize>>,
+        original_sql: Option<String>,
         resolved_sql: Option<String>,
     ) -> Result<StatementLineage, ParseError> {
         let mut ctx = StatementContext::new(index);
@@ -66,16 +68,36 @@ impl<'a> Analyzer<'a> {
                 // Normalize the model name to match how table references are normalized
                 // (e.g., Snowflake normalizes to uppercase)
                 let normalized_model_name = model_name.map(|n| self.normalize_table_name(n));
+                let model_node_type = original_sql
+                    .as_deref()
+                    .and_then(parse_dbt_model_materialization)
+                    .map(|materialization| match materialization {
+                        DbtMaterialization::View => NodeType::View,
+                    })
+                    .unwrap_or(NodeType::Table);
 
                 let sink_target_id = if let Some(ref name) = normalized_model_name {
                     // Register the model as a produced table so downstream files
                     // that reference it via `ref(...)` see a known relation.
-                    self.tracker.record_produced(name, index);
+                    if model_node_type == NodeType::View {
+                        self.tracker.record_view_produced(name, index);
+                    } else {
+                        self.tracker.record_produced(name, index);
+                    }
                     // Materialize the sink as the canonical relation node so it
                     // unifies with consumer FROM references sharing the same
                     // canonical name (see issue #32).
                     let (canonical_id, node_type) = self.tracker.relation_identity(name);
-                    let sink_id = ctx.ensure_model_relation_sink(name, canonical_id, node_type);
+                    let producer_span = original_source_range
+                        .as_ref()
+                        .map(|range| Span::new(range.start, range.end))
+                        .unwrap_or_else(|| Span::new(source_range.start, source_range.end));
+                    let sink_id = ctx.ensure_model_relation_sink(
+                        name,
+                        canonical_id,
+                        node_type,
+                        Some(producer_span),
+                    );
                     Some(sink_id.to_string())
                 } else {
                     ctx.ensure_output_node_with_model(None);
@@ -961,6 +983,30 @@ impl<'a> Analyzer<'a> {
     #[cfg(not(feature = "templating"))]
     fn is_dbt_mode(&self) -> bool {
         false
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DbtMaterialization {
+    View,
+}
+
+fn parse_dbt_model_materialization(sql: &str) -> Option<DbtMaterialization> {
+    let lower = sql.to_ascii_lowercase();
+    let materialized_index = lower.find("materialized")?;
+    let after_key = &lower[materialized_index + "materialized".len()..];
+    let equals_index = after_key.find('=')?;
+    let after_equals = after_key[equals_index + 1..].trim_start();
+    let quote = after_equals.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+
+    let rest = &after_equals[quote.len_utf8()..];
+    let end = rest.find(quote)?;
+    match &rest[..end] {
+        "view" => Some(DbtMaterialization::View),
+        _ => None,
     }
 }
 

--- a/crates/flowscope-core/src/analyzer/statements.rs
+++ b/crates/flowscope-core/src/analyzer/statements.rs
@@ -32,6 +32,20 @@ use tracing::{info, info_span};
 #[cfg(feature = "templating")]
 use crate::templater::TemplateMode;
 
+/// Build a `Span` from a byte range, rejecting inverted or missing ranges.
+///
+/// `Span::new` stores whatever it's given; a range whose `start > end` would
+/// silently produce a nonsense span that, downstream, could slice the wrong
+/// bytes. This helper normalizes the "no usable range" case to `None` so
+/// callers can fall back explicitly rather than propagate garbage.
+fn span_from_range(range: Option<&Range<usize>>) -> Option<Span> {
+    let range = range?;
+    if range.start > range.end {
+        return None;
+    }
+    Some(Span::new(range.start, range.end))
+}
+
 /// Information about a join node for dependency edge construction.
 struct JoinNodeInfo {
     /// Node ID of the joined table
@@ -97,26 +111,33 @@ impl<'a> Analyzer<'a> {
 
                 let sink_target_id: Option<Arc<str>> = if let Some(ref name) = normalized_model_name
                 {
-                    // Register the model as a produced table so downstream files
-                    // that reference it via `ref(...)` see a known relation.
-                    if model_node_type == NodeType::View {
-                        self.tracker.record_view_produced(name, index);
-                    } else {
-                        self.tracker.record_produced(name, index);
+                    // Register the model so downstream files that reference it via
+                    // `ref(...)` reuse the correct canonical sink identity.
+                    match model_node_type {
+                        NodeType::View => self.tracker.record_view_produced(name, index),
+                        NodeType::Table => self.tracker.record_produced(name, index),
+                        NodeType::Cte => self.tracker.declare_ephemeral(name),
+                        NodeType::Output | NodeType::Column => {
+                            unreachable!("dbt model sinks must be relation-like")
+                        }
                     }
                     // Materialize the sink as the canonical relation node so it
                     // unifies with consumer FROM references sharing the same
                     // canonical name (see issue #32).
                     let (canonical_id, node_type) = self.tracker.relation_identity(name);
-                    let producer_span = original_source_range
-                        .as_ref()
-                        .map(|range| Span::new(range.start, range.end))
-                        .unwrap_or_else(|| Span::new(source_range.start, source_range.end));
+                    // Prefer the untemplated range so the node's span points at
+                    // the user's original file, but fall back to the templated
+                    // range (and finally to None) if upstream hands us an
+                    // inverted/invalid range. `Span::new` doesn't enforce
+                    // start <= end, and an inverted span would slice the
+                    // wrong bytes downstream.
+                    let producer_span = span_from_range(original_source_range.as_ref())
+                        .or_else(|| span_from_range(Some(&source_range)));
                     Some(ctx.ensure_model_relation_sink(
                         name,
                         canonical_id,
                         node_type,
-                        Some(producer_span),
+                        producer_span,
                     ))
                 } else {
                     ctx.ensure_output_node_with_model(None);
@@ -1009,7 +1030,7 @@ impl<'a> Analyzer<'a> {
 /// fall through to `None` in the parser and are treated as the default
 /// (physical table) by the caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DbtMaterialization {
+pub(super) enum DbtMaterialization {
     Table,
     View,
     Incremental,
@@ -1021,16 +1042,15 @@ enum DbtMaterialization {
 impl DbtMaterialization {
     /// Maps a materialization to the lineage node type that best represents
     /// how downstream queries will observe it. `ephemeral` models are inlined
-    /// CTEs with no persisted relation, so they are treated as views for
-    /// lineage purposes.
+    /// CTEs with no persisted relation, so they are surfaced as `NodeType::Cte`
+    /// instead of fabricating a table/view sink.
     fn node_type(self) -> NodeType {
         match self {
             DbtMaterialization::Table
             | DbtMaterialization::Incremental
             | DbtMaterialization::Snapshot => NodeType::Table,
-            DbtMaterialization::View
-            | DbtMaterialization::Ephemeral
-            | DbtMaterialization::MaterializedView => NodeType::View,
+            DbtMaterialization::View | DbtMaterialization::MaterializedView => NodeType::View,
+            DbtMaterialization::Ephemeral => NodeType::Cte,
         }
     }
 }
@@ -1043,58 +1063,137 @@ static MATERIALIZED_KWARG: LazyLock<Regex> = LazyLock::new(|| {
         .expect("materialized kwarg regex is valid")
 });
 
-/// Parses the dbt materialization from the raw (untemplated) model SQL.
-///
-/// Scoped to the bodies of `config(...)` calls so that the word
-/// `materialized` appearing elsewhere (column names, comments, string
-/// literals outside `config`) cannot produce false positives. When multiple
-/// `config(...)` calls set `materialized`, the last one wins to match dbt's
-/// config override behavior.
-fn parse_dbt_model_materialization(sql: &str) -> Option<DbtMaterialization> {
-    let mut search_from = 0;
-    let mut last_value = None;
+/// Matches the `materialized=` kwarg in any form — literal, Jinja expression,
+/// adapter-specific value — so we can distinguish "model set materialized to
+/// something we couldn't parse" from "model never configured materialized".
+/// Requires a word boundary before `materialized` so substrings like
+/// `pre_materialized=` don't count.
+static MATERIALIZED_KWARG_PRESENT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(^|[^A-Za-z0-9_])materialized\s*=")
+        .expect("materialized presence regex is valid")
+});
 
-    while let Some((body, next_search_from)) = find_next_config_call_body(sql, search_from) {
+/// Outcome of parsing `config(...)` blocks for the `materialized` kwarg.
+///
+/// Distinguishes three user-visible states so callers can both pick a sensible
+/// default node type and, when relevant, surface a warning to the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DbtMaterializationDetection {
+    /// No `config(...)` block set `materialized=...`. Treat as the default
+    /// (physical table) without warning.
+    NotConfigured,
+    /// `materialized=...` parsed to a known dbt materialization.
+    Known(DbtMaterialization),
+    /// `materialized=...` was present but couldn't be resolved — a dynamic
+    /// Jinja expression, a non-literal value, or an adapter-specific name
+    /// outside our known set. Callers should fall back to `Table` and
+    /// typically emit a warning so users know lineage may be off.
+    Unresolved,
+}
+
+impl DbtMaterializationDetection {
+    /// Returns the lineage node type implied by a successful detection, or
+    /// `None` for the `NotConfigured` / `Unresolved` cases where callers must
+    /// fall back to their own default.
+    pub(super) fn node_type(self) -> Option<NodeType> {
+        match self {
+            DbtMaterializationDetection::Known(m) => Some(m.node_type()),
+            DbtMaterializationDetection::NotConfigured
+            | DbtMaterializationDetection::Unresolved => None,
+        }
+    }
+}
+
+/// Detects the dbt materialization from raw (untemplated) model SQL.
+///
+/// Scoped to the bodies of `config(...)` calls so the word `materialized`
+/// appearing in column names, comments, or string literals elsewhere cannot
+/// produce false positives. When multiple `config(...)` calls set
+/// `materialized`, the last one wins to match dbt's config override behavior.
+pub(super) fn detect_dbt_model_materialization(sql: &str) -> DbtMaterializationDetection {
+    // Lowercase once up front so both the config-scanner and the
+    // presence-check avoid re-allocating per call. ASCII-only content matches
+    // `sql` byte-for-byte, which is fine because `config`, `materialized`,
+    // and all known materialization keywords are ASCII.
+    let lower = sql.to_ascii_lowercase();
+    let mut search_from = 0;
+    let mut last_value: Option<String> = None;
+    let mut saw_materialized_kwarg = false;
+
+    while let Some((body_range, next_search_from)) =
+        find_next_config_call_body(sql, &lower, search_from)
+    {
+        let body = &sql[body_range.clone()];
+        if !saw_materialized_kwarg && MATERIALIZED_KWARG_PRESENT.is_match(body) {
+            saw_materialized_kwarg = true;
+        }
         if let Some(captures) = MATERIALIZED_KWARG.captures(body) {
             last_value = captures
                 .get(1)
                 .or_else(|| captures.get(2))
-                .map(|m| m.as_str());
+                .map(|m| m.as_str().to_string());
         }
         search_from = next_search_from;
     }
 
-    match last_value?.to_ascii_lowercase().as_str() {
-        "table" => Some(DbtMaterialization::Table),
-        "view" => Some(DbtMaterialization::View),
-        "incremental" => Some(DbtMaterialization::Incremental),
-        "ephemeral" => Some(DbtMaterialization::Ephemeral),
-        "snapshot" => Some(DbtMaterialization::Snapshot),
-        "materialized_view" => Some(DbtMaterialization::MaterializedView),
-        _ => None,
+    if let Some(raw) = last_value {
+        match raw.to_ascii_lowercase().as_str() {
+            "table" => DbtMaterializationDetection::Known(DbtMaterialization::Table),
+            "view" => DbtMaterializationDetection::Known(DbtMaterialization::View),
+            "incremental" => DbtMaterializationDetection::Known(DbtMaterialization::Incremental),
+            "ephemeral" => DbtMaterializationDetection::Known(DbtMaterialization::Ephemeral),
+            "snapshot" => DbtMaterializationDetection::Known(DbtMaterialization::Snapshot),
+            "materialized_view" => {
+                DbtMaterializationDetection::Known(DbtMaterialization::MaterializedView)
+            }
+            _ => DbtMaterializationDetection::Unresolved,
+        }
+    } else if saw_materialized_kwarg {
+        DbtMaterializationDetection::Unresolved
+    } else {
+        DbtMaterializationDetection::NotConfigured
     }
 }
 
 pub(super) fn dbt_model_relation_type(sql: Option<&str>) -> NodeType {
-    sql.and_then(parse_dbt_model_materialization)
-        .map(DbtMaterialization::node_type)
-        .unwrap_or(NodeType::Table)
+    match sql.map(detect_dbt_model_materialization) {
+        Some(DbtMaterializationDetection::Known(m)) => m.node_type(),
+        _ => NodeType::Table,
+    }
 }
 
-/// Returns the substring between the opening `(` of the next `config(...)`
-/// call in `sql[search_from..]` and its matching `)`, plus the byte index to
-/// continue searching from.
+/// Upper bound on paren-match iterations inside a single `config(...)` body.
+/// A well-formed dbt model is orders of magnitude below this; the guard
+/// exists so pathological input (huge generated files, malicious payloads)
+/// can't wedge the parser.
+const CONFIG_BODY_SCAN_LIMIT: usize = 1_000_000;
+
+/// Upper bound on nested paren depth inside a `config(...)` body. Real dbt
+/// configs rarely exceed single-digit nesting; this rules out stack-style
+/// abuse without touching the fast path.
+const CONFIG_BODY_MAX_DEPTH: u32 = 256;
+
+/// Returns the byte range (inside `sql`) of the next `config(...)` call's
+/// body (between `(` and the matching `)`), plus the byte index to continue
+/// searching from.
 ///
 /// Tracks paren depth while skipping over string literals (single and double
 /// quoted, with `\` escapes), so nested calls like
 /// `config(materialized='view', partition_by=date_trunc('day', x))` resolve
 /// correctly. Requires `config` to be a standalone identifier (not a suffix
 /// of another word). Returns `None` if no `config(` is found after
-/// `search_from` or the call is unterminated.
-fn find_next_config_call_body(sql: &str, search_from: usize) -> Option<(&str, usize)> {
-    // `config` is ASCII, so byte-indexing the lowercased copy matches `sql`
-    // byte-for-byte.
-    let lower = sql.to_ascii_lowercase();
+/// `search_from`, if the call is unterminated, or if the scan hits the
+/// robustness guards ([`CONFIG_BODY_SCAN_LIMIT`] /
+/// [`CONFIG_BODY_MAX_DEPTH`]).
+///
+/// `lower` must be `sql.to_ascii_lowercase()` — passed in so callers that
+/// invoke this in a loop only pay the allocation once.
+fn find_next_config_call_body(
+    sql: &str,
+    lower: &str,
+    search_from: usize,
+) -> Option<(Range<usize>, usize)> {
+    debug_assert_eq!(sql.len(), lower.len());
     let bytes = sql.as_bytes();
     let mut search_from = search_from;
 
@@ -1125,7 +1224,12 @@ fn find_next_config_call_body(sql: &str, search_from: usize) -> Option<(&str, us
         let mut depth: u32 = 1;
         let mut quote: Option<u8> = None;
         let mut i = body_start;
+        let mut iterations: usize = 0;
         while i < bytes.len() {
+            iterations += 1;
+            if iterations > CONFIG_BODY_SCAN_LIMIT {
+                return None;
+            }
             let b = bytes[i];
             if let Some(q) = quote {
                 if b == b'\\' && i + 1 < bytes.len() {
@@ -1138,11 +1242,16 @@ fn find_next_config_call_body(sql: &str, search_from: usize) -> Option<(&str, us
             } else {
                 match b {
                     b'\'' | b'"' => quote = Some(b),
-                    b'(' => depth += 1,
+                    b'(' => {
+                        depth += 1;
+                        if depth > CONFIG_BODY_MAX_DEPTH {
+                            return None;
+                        }
+                    }
                     b')' => {
                         depth -= 1;
                         if depth == 0 {
-                            return Some((&sql[body_start..i], i + 1));
+                            return Some((body_start..i, i + 1));
                         }
                     }
                     _ => {}
@@ -1158,43 +1267,40 @@ fn find_next_config_call_body(sql: &str, search_from: usize) -> Option<(&str, us
 
 #[cfg(test)]
 mod dbt_materialization_tests {
-    use super::{parse_dbt_model_materialization, DbtMaterialization};
+    use super::{
+        detect_dbt_model_materialization, DbtMaterialization, DbtMaterializationDetection,
+    };
+
+    fn known(sql: &str) -> Option<DbtMaterialization> {
+        match detect_dbt_model_materialization(sql) {
+            DbtMaterializationDetection::Known(m) => Some(m),
+            _ => None,
+        }
+    }
 
     #[test]
     fn matches_single_quoted_view() {
         let sql = "{{ config(materialized='view') }}\nSELECT 1";
-        assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
-        );
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
     }
 
     #[test]
     fn matches_double_quoted_view() {
         let sql = r#"{{ config(materialized="view") }} SELECT 1"#;
-        assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
-        );
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
     }
 
     #[test]
     fn tolerates_whitespace_around_tokens() {
         let sql = "{{ config (  materialized   =   'view'  ) }} SELECT 1";
-        assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
-        );
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
     }
 
     #[test]
     fn handles_nested_parens_in_sibling_kwargs() {
         let sql = "{{ config(materialized='view', partition_by=date_trunc('day', ts)) }} \
                    SELECT 1";
-        assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
-        );
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
     }
 
     #[test]
@@ -1210,7 +1316,7 @@ mod dbt_materialization_tests {
         for (keyword, expected) in cases {
             let sql = format!("{{{{ config(materialized='{keyword}') }}}} SELECT 1");
             assert_eq!(
-                parse_dbt_model_materialization(&sql),
+                known(&sql),
                 Some(expected),
                 "failed for materialization '{keyword}'"
             );
@@ -1218,9 +1324,12 @@ mod dbt_materialization_tests {
     }
 
     #[test]
-    fn unknown_materialization_returns_none() {
+    fn unknown_materialization_returns_unresolved() {
         let sql = "{{ config(materialized='customthing') }} SELECT 1";
-        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::Unresolved
+        );
     }
 
     #[test]
@@ -1230,7 +1339,7 @@ mod dbt_materialization_tests {
         assert_eq!(DbtMaterialization::Incremental.node_type(), NodeType::Table);
         assert_eq!(DbtMaterialization::Snapshot.node_type(), NodeType::Table);
         assert_eq!(DbtMaterialization::View.node_type(), NodeType::View);
-        assert_eq!(DbtMaterialization::Ephemeral.node_type(), NodeType::View);
+        assert_eq!(DbtMaterialization::Ephemeral.node_type(), NodeType::Cte);
         assert_eq!(
             DbtMaterialization::MaterializedView.node_type(),
             NodeType::View
@@ -1240,86 +1349,113 @@ mod dbt_materialization_tests {
     #[test]
     fn ignores_materialized_outside_config() {
         let sql = "-- materialized='view'\nSELECT materialized FROM t";
-        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::NotConfigured
+        );
     }
 
     #[test]
     fn ignores_config_substring_of_another_identifier() {
         let sql = "{{ reconfig(materialized='view') }} SELECT 1";
-        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::NotConfigured
+        );
     }
 
     #[test]
-    fn unterminated_config_call_returns_none() {
+    fn unterminated_config_call_returns_not_configured() {
         let sql = "{{ config(materialized='view'";
-        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::NotConfigured
+        );
     }
 
     #[test]
     fn paren_inside_string_does_not_close_config() {
         let sql = r#"{{ config(alias=')', materialized='view') }} SELECT 1"#;
-        assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
-        );
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
     }
 
     #[test]
     fn case_insensitive_keywords() {
         let sql = "{{ CONFIG(MATERIALIZED='VIEW') }} SELECT 1";
-        assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
-        );
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
     }
 
     #[test]
-    fn returns_none_when_materialized_kwarg_missing() {
+    fn returns_not_configured_when_materialized_kwarg_missing() {
         let sql = "{{ config(tags=['daily']) }} SELECT 1";
-        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::NotConfigured
+        );
     }
 
     #[test]
     fn finds_materialized_in_later_config_call() {
         let sql = "{{ config(tags=['daily']) }} {{ config(materialized='view') }} SELECT 1";
-        assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
-        );
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
     }
 
     #[test]
     fn later_config_call_overrides_earlier_materialized_value() {
         let sql = "{{ config(materialized='table') }} {{ config(materialized='view') }} SELECT 1";
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
+    }
+
+    #[test]
+    fn escaped_quote_in_earlier_kwarg_does_not_break_parsing() {
+        // Single-quoted string with an escaped apostrophe must not swallow the
+        // rest of the config body or trip up the kwarg regex that follows.
+        let sql = r#"{{ config(alias='don\'t', materialized='view') }} SELECT 1"#;
+        assert_eq!(known(sql), Some(DbtMaterialization::View));
+    }
+
+    #[test]
+    fn escaped_quote_inside_materialized_value_is_unresolved() {
+        // Value isn't a bare `\w+`, so the literal regex can't capture it.
+        // Presence detector still fires, so we report Unresolved rather than
+        // silently defaulting to table.
+        let sql = r#"{{ config(materialized='it\'s_a_view') }} SELECT 1"#;
         assert_eq!(
-            parse_dbt_model_materialization(sql),
-            Some(DbtMaterialization::View)
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::Unresolved
         );
     }
 
     #[test]
-    fn unknown_adapter_materialization_defaults_to_table() {
+    fn unknown_adapter_materialization_reports_unresolved_and_defaults_to_table() {
         use super::dbt_model_relation_type;
         use crate::types::NodeType;
         // Custom adapter materializations (e.g., Databricks delta live tables,
-        // Snowflake dynamic tables) are not in our known set. Parsing returns
-        // `None` so the caller falls back to `NodeType::Table`.
+        // Snowflake dynamic tables) aren't in our known set. We surface that as
+        // `Unresolved` so callers can warn, but still fall back to `Table` for
+        // the node type.
         let sql = "{{ config(materialized='dynamic_table') }} SELECT 1";
-        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::Unresolved
+        );
         assert_eq!(dbt_model_relation_type(Some(sql)), NodeType::Table);
     }
 
     #[test]
-    fn dynamic_jinja_materialization_falls_back_to_table() {
+    fn dynamic_jinja_materialization_reports_unresolved_and_defaults_to_table() {
         use super::dbt_model_relation_type;
         use crate::types::NodeType;
-        // A Jinja expression as the materialized value is not a bare identifier
-        // in quotes, so the kwarg regex does not match and we fall back to the
-        // default table materialization. Pinning this behavior explicitly so a
-        // future regex widening is a conscious choice rather than an accident.
+        // A Jinja expression as the value is not a quoted bare identifier.
+        // The literal-value regex doesn't match, but the presence regex does,
+        // so detection returns `Unresolved` — letting callers warn while the
+        // node type falls back to `Table`.
         let sql =
             "{{ config(materialized=('view' if target.name == 'dev' else 'table')) }} SELECT 1";
-        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(
+            detect_dbt_model_materialization(sql),
+            DbtMaterializationDetection::Unresolved
+        );
         assert_eq!(dbt_model_relation_type(Some(sql)), NodeType::Table);
     }
 }

--- a/crates/flowscope-core/src/analyzer/statements.rs
+++ b/crates/flowscope-core/src/analyzer/statements.rs
@@ -42,18 +42,42 @@ struct JoinNodeInfo {
     join_condition: Option<Arc<str>>,
 }
 
+/// Source-text bookkeeping for a single statement passed to the analyzer.
+///
+/// Bundles both the templated and (when applicable) the untemplated source
+/// ranges plus raw SQL, so statement-level analysis has a single handle to
+/// the text it's analyzing. dbt materialization detection needs the
+/// untemplated form; `StatementLineage` surfaces the resolved form to
+/// downstream consumers.
+pub(super) struct StatementSource {
+    /// Byte range of this statement in the (possibly templated) source SQL.
+    pub source_range: Range<usize>,
+    /// Byte range of this statement in the untemplated source, when templating
+    /// was applied. Used so spans computed for dbt producers point at the
+    /// user's original file rather than the rendered output.
+    pub original_source_range: Option<Range<usize>>,
+    /// Untemplated SQL text for this statement, when templating was applied.
+    pub original_sql: Option<String>,
+    /// Resolved SQL text when templating was applied. Preserved on the
+    /// statement lineage for downstream consumers.
+    pub resolved_sql: Option<String>,
+}
+
 impl<'a> Analyzer<'a> {
-    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, statement), fields(index, source = source_name.as_deref())))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, statement, source), fields(index, name = source_name.as_deref())))]
     pub(super) fn analyze_statement(
         &mut self,
         index: usize,
         statement: &Statement,
         source_name: Option<String>,
-        source_range: Range<usize>,
-        original_source_range: Option<Range<usize>>,
-        original_sql: Option<String>,
-        resolved_sql: Option<String>,
+        source: StatementSource,
     ) -> Result<StatementLineage, ParseError> {
+        let StatementSource {
+            source_range,
+            original_source_range,
+            original_sql,
+            resolved_sql,
+        } = source;
         let mut ctx = StatementContext::new(index);
 
         let statement_type = match statement {
@@ -71,7 +95,8 @@ impl<'a> Analyzer<'a> {
                 let normalized_model_name = model_name.map(|n| self.normalize_table_name(n));
                 let model_node_type = dbt_model_relation_type(original_sql.as_deref());
 
-                let sink_target_id = if let Some(ref name) = normalized_model_name {
+                let sink_target_id: Option<Arc<str>> = if let Some(ref name) = normalized_model_name
+                {
                     // Register the model as a produced table so downstream files
                     // that reference it via `ref(...)` see a known relation.
                     if model_node_type == NodeType::View {
@@ -87,13 +112,12 @@ impl<'a> Analyzer<'a> {
                         .as_ref()
                         .map(|range| Span::new(range.start, range.end))
                         .unwrap_or_else(|| Span::new(source_range.start, source_range.end));
-                    let sink_id = ctx.ensure_model_relation_sink(
+                    Some(ctx.ensure_model_relation_sink(
                         name,
                         canonical_id,
                         node_type,
                         Some(producer_span),
-                    );
-                    Some(sink_id.to_string())
+                    ))
                 } else {
                     ctx.ensure_output_node_with_model(None);
                     None
@@ -283,7 +307,7 @@ impl<'a> Analyzer<'a> {
     }
 
     fn add_join_dependency_edges(&self, ctx: &mut StatementContext) {
-        let output_node_id = match ctx.output_node_id.as_ref() {
+        let sink_node_id = match ctx.sink_node_id.as_ref() {
             Some(node_id) => node_id.clone(),
             None => return,
         };
@@ -291,7 +315,7 @@ impl<'a> Analyzer<'a> {
         let output_column_ids: HashSet<_> = if self.column_lineage_enabled {
             ctx.edges
                 .iter()
-                .filter(|edge| edge.edge_type == EdgeType::Ownership && edge.from == output_node_id)
+                .filter(|edge| edge.edge_type == EdgeType::Ownership && edge.from == sink_node_id)
                 .map(|edge| edge.to.clone())
                 .collect()
         } else {
@@ -300,7 +324,7 @@ impl<'a> Analyzer<'a> {
         if self.column_lineage_enabled {
             let has_direct_output_lineage = ctx.edges.iter().any(|edge| {
                 matches!(edge.edge_type, EdgeType::DataFlow | EdgeType::Derivation)
-                    && edge.to == output_node_id
+                    && edge.to == sink_node_id
             });
             if output_column_ids.is_empty() && !has_direct_output_lineage {
                 return;
@@ -347,7 +371,7 @@ impl<'a> Analyzer<'a> {
                     matches!(edge.edge_type, EdgeType::DataFlow | EdgeType::Derivation)
                         && (edge.from == node_id
                             || owned_columns.iter().any(|col| col == &edge.from))
-                        && (edge.to == output_node_id || output_column_ids.contains(&edge.to))
+                        && (edge.to == sink_node_id || output_column_ids.contains(&edge.to))
                 })
             } else {
                 false
@@ -361,7 +385,7 @@ impl<'a> Analyzer<'a> {
                 "join_dependency:{node_id}:{join_type:?}:{}",
                 join_condition.as_deref().unwrap_or("")
             );
-            let edge_id = generate_edge_id(&edge_key, output_node_id.as_ref());
+            let edge_id = generate_edge_id(&edge_key, sink_node_id.as_ref());
             if ctx.edge_ids.contains(&edge_id) {
                 continue;
             }
@@ -369,7 +393,7 @@ impl<'a> Analyzer<'a> {
             ctx.add_edge(Edge {
                 id: edge_id,
                 from: node_id,
-                to: output_node_id.clone(),
+                to: sink_node_id.clone(),
                 edge_type: EdgeType::JoinDependency,
                 expression: None,
                 operation: None,
@@ -1021,14 +1045,26 @@ static MATERIALIZED_KWARG: LazyLock<Regex> = LazyLock::new(|| {
 
 /// Parses the dbt materialization from the raw (untemplated) model SQL.
 ///
-/// Scoped to the body of the first `config(...)` call so that the word
+/// Scoped to the bodies of `config(...)` calls so that the word
 /// `materialized` appearing elsewhere (column names, comments, string
-/// literals outside `config`) cannot produce false positives.
+/// literals outside `config`) cannot produce false positives. When multiple
+/// `config(...)` calls set `materialized`, the last one wins to match dbt's
+/// config override behavior.
 fn parse_dbt_model_materialization(sql: &str) -> Option<DbtMaterialization> {
-    let body = find_config_call_body(sql)?;
-    let captures = MATERIALIZED_KWARG.captures(body)?;
-    let value = captures.get(1).or_else(|| captures.get(2))?.as_str();
-    match value.to_ascii_lowercase().as_str() {
+    let mut search_from = 0;
+    let mut last_value = None;
+
+    while let Some((body, next_search_from)) = find_next_config_call_body(sql, search_from) {
+        if let Some(captures) = MATERIALIZED_KWARG.captures(body) {
+            last_value = captures
+                .get(1)
+                .or_else(|| captures.get(2))
+                .map(|m| m.as_str());
+        }
+        search_from = next_search_from;
+    }
+
+    match last_value?.to_ascii_lowercase().as_str() {
         "table" => Some(DbtMaterialization::Table),
         "view" => Some(DbtMaterialization::View),
         "incremental" => Some(DbtMaterialization::Incremental),
@@ -1045,21 +1081,22 @@ pub(super) fn dbt_model_relation_type(sql: Option<&str>) -> NodeType {
         .unwrap_or(NodeType::Table)
 }
 
-/// Returns the substring between the opening `(` of the first `config(...)`
-/// call in `sql` and its matching `)`.
+/// Returns the substring between the opening `(` of the next `config(...)`
+/// call in `sql[search_from..]` and its matching `)`, plus the byte index to
+/// continue searching from.
 ///
 /// Tracks paren depth while skipping over string literals (single and double
 /// quoted, with `\` escapes), so nested calls like
 /// `config(materialized='view', partition_by=date_trunc('day', x))` resolve
 /// correctly. Requires `config` to be a standalone identifier (not a suffix
-/// of another word). Returns `None` if no `config(` is found or the call is
-/// unterminated.
-fn find_config_call_body(sql: &str) -> Option<&str> {
+/// of another word). Returns `None` if no `config(` is found after
+/// `search_from` or the call is unterminated.
+fn find_next_config_call_body(sql: &str, search_from: usize) -> Option<(&str, usize)> {
     // `config` is ASCII, so byte-indexing the lowercased copy matches `sql`
     // byte-for-byte.
     let lower = sql.to_ascii_lowercase();
     let bytes = sql.as_bytes();
-    let mut search_from = 0;
+    let mut search_from = search_from;
 
     while let Some(rel) = lower[search_from..].find("config") {
         let start = search_from + rel;
@@ -1105,7 +1142,7 @@ fn find_config_call_body(sql: &str) -> Option<&str> {
                     b')' => {
                         depth -= 1;
                         if depth == 0 {
-                            return Some(&sql[body_start..i]);
+                            return Some((&sql[body_start..i], i + 1));
                         }
                     }
                     _ => {}
@@ -1240,6 +1277,50 @@ mod dbt_materialization_tests {
     fn returns_none_when_materialized_kwarg_missing() {
         let sql = "{{ config(tags=['daily']) }} SELECT 1";
         assert_eq!(parse_dbt_model_materialization(sql), None);
+    }
+
+    #[test]
+    fn finds_materialized_in_later_config_call() {
+        let sql = "{{ config(tags=['daily']) }} {{ config(materialized='view') }} SELECT 1";
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn later_config_call_overrides_earlier_materialized_value() {
+        let sql = "{{ config(materialized='table') }} {{ config(materialized='view') }} SELECT 1";
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn unknown_adapter_materialization_defaults_to_table() {
+        use super::dbt_model_relation_type;
+        use crate::types::NodeType;
+        // Custom adapter materializations (e.g., Databricks delta live tables,
+        // Snowflake dynamic tables) are not in our known set. Parsing returns
+        // `None` so the caller falls back to `NodeType::Table`.
+        let sql = "{{ config(materialized='dynamic_table') }} SELECT 1";
+        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(dbt_model_relation_type(Some(sql)), NodeType::Table);
+    }
+
+    #[test]
+    fn dynamic_jinja_materialization_falls_back_to_table() {
+        use super::dbt_model_relation_type;
+        use crate::types::NodeType;
+        // A Jinja expression as the materialized value is not a bare identifier
+        // in quotes, so the kwarg regex does not match and we fall back to the
+        // default table materialization. Pinning this behavior explicitly so a
+        // future regex widening is a conscious choice rather than an accident.
+        let sql =
+            "{{ config(materialized=('view' if target.name == 'dev' else 'table')) }} SELECT 1";
+        assert_eq!(parse_dbt_model_materialization(sql), None);
+        assert_eq!(dbt_model_relation_type(Some(sql)), NodeType::Table);
     }
 }
 

--- a/crates/flowscope-core/src/analyzer/statements.rs
+++ b/crates/flowscope-core/src/analyzer/statements.rs
@@ -17,6 +17,7 @@ use crate::error::ParseError;
 use crate::types::{
     issue_codes, Edge, EdgeType, Issue, JoinType, Node, NodeType, Span, StatementLineage,
 };
+use regex::Regex;
 use sqlparser::ast::{
     self, AlterTableOperation, Assignment, CopyIntoSnowflakeKind, CopySource, CopyTarget, Expr,
     FromTable, MergeAction, MergeClause, MergeInsertKind, ObjectName, RenameTableNameKind,
@@ -24,7 +25,7 @@ use sqlparser::ast::{
 };
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 #[cfg(feature = "tracing")]
 use tracing::{info, info_span};
 
@@ -68,13 +69,7 @@ impl<'a> Analyzer<'a> {
                 // Normalize the model name to match how table references are normalized
                 // (e.g., Snowflake normalizes to uppercase)
                 let normalized_model_name = model_name.map(|n| self.normalize_table_name(n));
-                let model_node_type = original_sql
-                    .as_deref()
-                    .and_then(parse_dbt_model_materialization)
-                    .map(|materialization| match materialization {
-                        DbtMaterialization::View => NodeType::View,
-                    })
-                    .unwrap_or(NodeType::Table);
+                let model_node_type = dbt_model_relation_type(original_sql.as_deref());
 
                 let sink_target_id = if let Some(ref name) = normalized_model_name {
                     // Register the model as a produced table so downstream files
@@ -971,7 +966,7 @@ impl<'a> Analyzer<'a> {
 
     /// Checks if the analyzer is running in dbt template mode.
     #[cfg(feature = "templating")]
-    fn is_dbt_mode(&self) -> bool {
+    pub(super) fn is_dbt_mode(&self) -> bool {
         self.request
             .template_config
             .as_ref()
@@ -981,32 +976,270 @@ impl<'a> Analyzer<'a> {
 
     /// Checks if the analyzer is running in dbt template mode.
     #[cfg(not(feature = "templating"))]
-    fn is_dbt_mode(&self) -> bool {
+    pub(super) fn is_dbt_mode(&self) -> bool {
         false
     }
 }
 
+/// Recognized dbt materializations. Adapter-specific values not listed here
+/// fall through to `None` in the parser and are treated as the default
+/// (physical table) by the caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DbtMaterialization {
+    Table,
     View,
+    Incremental,
+    Ephemeral,
+    Snapshot,
+    MaterializedView,
 }
 
+impl DbtMaterialization {
+    /// Maps a materialization to the lineage node type that best represents
+    /// how downstream queries will observe it. `ephemeral` models are inlined
+    /// CTEs with no persisted relation, so they are treated as views for
+    /// lineage purposes.
+    fn node_type(self) -> NodeType {
+        match self {
+            DbtMaterialization::Table
+            | DbtMaterialization::Incremental
+            | DbtMaterialization::Snapshot => NodeType::Table,
+            DbtMaterialization::View
+            | DbtMaterialization::Ephemeral
+            | DbtMaterialization::MaterializedView => NodeType::View,
+        }
+    }
+}
+
+/// Matches a `materialized='value'` kwarg. Value must be a bare identifier
+/// (word chars), which fits every real dbt materialization and avoids
+/// matching inside arbitrary strings.
+static MATERIALIZED_KWARG: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)materialized\s*=\s*(?:'(\w+)'|"(\w+)")"#)
+        .expect("materialized kwarg regex is valid")
+});
+
+/// Parses the dbt materialization from the raw (untemplated) model SQL.
+///
+/// Scoped to the body of the first `config(...)` call so that the word
+/// `materialized` appearing elsewhere (column names, comments, string
+/// literals outside `config`) cannot produce false positives.
 fn parse_dbt_model_materialization(sql: &str) -> Option<DbtMaterialization> {
+    let body = find_config_call_body(sql)?;
+    let captures = MATERIALIZED_KWARG.captures(body)?;
+    let value = captures.get(1).or_else(|| captures.get(2))?.as_str();
+    match value.to_ascii_lowercase().as_str() {
+        "table" => Some(DbtMaterialization::Table),
+        "view" => Some(DbtMaterialization::View),
+        "incremental" => Some(DbtMaterialization::Incremental),
+        "ephemeral" => Some(DbtMaterialization::Ephemeral),
+        "snapshot" => Some(DbtMaterialization::Snapshot),
+        "materialized_view" => Some(DbtMaterialization::MaterializedView),
+        _ => None,
+    }
+}
+
+pub(super) fn dbt_model_relation_type(sql: Option<&str>) -> NodeType {
+    sql.and_then(parse_dbt_model_materialization)
+        .map(DbtMaterialization::node_type)
+        .unwrap_or(NodeType::Table)
+}
+
+/// Returns the substring between the opening `(` of the first `config(...)`
+/// call in `sql` and its matching `)`.
+///
+/// Tracks paren depth while skipping over string literals (single and double
+/// quoted, with `\` escapes), so nested calls like
+/// `config(materialized='view', partition_by=date_trunc('day', x))` resolve
+/// correctly. Requires `config` to be a standalone identifier (not a suffix
+/// of another word). Returns `None` if no `config(` is found or the call is
+/// unterminated.
+fn find_config_call_body(sql: &str) -> Option<&str> {
+    // `config` is ASCII, so byte-indexing the lowercased copy matches `sql`
+    // byte-for-byte.
     let lower = sql.to_ascii_lowercase();
-    let materialized_index = lower.find("materialized")?;
-    let after_key = &lower[materialized_index + "materialized".len()..];
-    let equals_index = after_key.find('=')?;
-    let after_equals = after_key[equals_index + 1..].trim_start();
-    let quote = after_equals.chars().next()?;
-    if quote != '\'' && quote != '"' {
+    let bytes = sql.as_bytes();
+    let mut search_from = 0;
+
+    while let Some(rel) = lower[search_from..].find("config") {
+        let start = search_from + rel;
+        let after_keyword = start + "config".len();
+
+        // Reject `reconfig`, `preconfigure`, etc.
+        if start > 0 {
+            let prev = bytes[start - 1];
+            if prev.is_ascii_alphanumeric() || prev == b'_' {
+                search_from = after_keyword;
+                continue;
+            }
+        }
+
+        // Allow whitespace between `config` and `(`.
+        let mut cursor = after_keyword;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= bytes.len() || bytes[cursor] != b'(' {
+            search_from = after_keyword;
+            continue;
+        }
+
+        let body_start = cursor + 1;
+        let mut depth: u32 = 1;
+        let mut quote: Option<u8> = None;
+        let mut i = body_start;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if let Some(q) = quote {
+                if b == b'\\' && i + 1 < bytes.len() {
+                    i += 2;
+                    continue;
+                }
+                if b == q {
+                    quote = None;
+                }
+            } else {
+                match b {
+                    b'\'' | b'"' => quote = Some(b),
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(&sql[body_start..i]);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            i += 1;
+        }
         return None;
     }
 
-    let rest = &after_equals[quote.len_utf8()..];
-    let end = rest.find(quote)?;
-    match &rest[..end] {
-        "view" => Some(DbtMaterialization::View),
-        _ => None,
+    None
+}
+
+#[cfg(test)]
+mod dbt_materialization_tests {
+    use super::{parse_dbt_model_materialization, DbtMaterialization};
+
+    #[test]
+    fn matches_single_quoted_view() {
+        let sql = "{{ config(materialized='view') }}\nSELECT 1";
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn matches_double_quoted_view() {
+        let sql = r#"{{ config(materialized="view") }} SELECT 1"#;
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn tolerates_whitespace_around_tokens() {
+        let sql = "{{ config (  materialized   =   'view'  ) }} SELECT 1";
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn handles_nested_parens_in_sibling_kwargs() {
+        let sql = "{{ config(materialized='view', partition_by=date_trunc('day', ts)) }} \
+                   SELECT 1";
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn recognizes_all_known_materializations() {
+        let cases = [
+            ("table", DbtMaterialization::Table),
+            ("view", DbtMaterialization::View),
+            ("incremental", DbtMaterialization::Incremental),
+            ("ephemeral", DbtMaterialization::Ephemeral),
+            ("snapshot", DbtMaterialization::Snapshot),
+            ("materialized_view", DbtMaterialization::MaterializedView),
+        ];
+        for (keyword, expected) in cases {
+            let sql = format!("{{{{ config(materialized='{keyword}') }}}} SELECT 1");
+            assert_eq!(
+                parse_dbt_model_materialization(&sql),
+                Some(expected),
+                "failed for materialization '{keyword}'"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_materialization_returns_none() {
+        let sql = "{{ config(materialized='customthing') }} SELECT 1";
+        assert_eq!(parse_dbt_model_materialization(sql), None);
+    }
+
+    #[test]
+    fn node_type_mapping() {
+        use crate::types::NodeType;
+        assert_eq!(DbtMaterialization::Table.node_type(), NodeType::Table);
+        assert_eq!(DbtMaterialization::Incremental.node_type(), NodeType::Table);
+        assert_eq!(DbtMaterialization::Snapshot.node_type(), NodeType::Table);
+        assert_eq!(DbtMaterialization::View.node_type(), NodeType::View);
+        assert_eq!(DbtMaterialization::Ephemeral.node_type(), NodeType::View);
+        assert_eq!(
+            DbtMaterialization::MaterializedView.node_type(),
+            NodeType::View
+        );
+    }
+
+    #[test]
+    fn ignores_materialized_outside_config() {
+        let sql = "-- materialized='view'\nSELECT materialized FROM t";
+        assert_eq!(parse_dbt_model_materialization(sql), None);
+    }
+
+    #[test]
+    fn ignores_config_substring_of_another_identifier() {
+        let sql = "{{ reconfig(materialized='view') }} SELECT 1";
+        assert_eq!(parse_dbt_model_materialization(sql), None);
+    }
+
+    #[test]
+    fn unterminated_config_call_returns_none() {
+        let sql = "{{ config(materialized='view'";
+        assert_eq!(parse_dbt_model_materialization(sql), None);
+    }
+
+    #[test]
+    fn paren_inside_string_does_not_close_config() {
+        let sql = r#"{{ config(alias=')', materialized='view') }} SELECT 1"#;
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn case_insensitive_keywords() {
+        let sql = "{{ CONFIG(MATERIALIZED='VIEW') }} SELECT 1";
+        assert_eq!(
+            parse_dbt_model_materialization(sql),
+            Some(DbtMaterialization::View)
+        );
+    }
+
+    #[test]
+    fn returns_none_when_materialized_kwarg_missing() {
+        let sql = "{{ config(tags=['daily']) }} SELECT 1";
+        assert_eq!(parse_dbt_model_materialization(sql), None);
     }
 }
 
@@ -1015,7 +1248,7 @@ fn parse_dbt_model_materialization(sql: &str) -> Option<DbtMaterialization> {
 /// Given a path like `models/staging/stg_customers.sql`, extracts `stg_customers`.
 /// Supports both `.sql` and `.sql.jinja` file extensions used by dbt.
 /// This is used to register dbt model outputs for cross-statement linking.
-fn extract_model_name(path: &str) -> &str {
+pub(super) fn extract_model_name(path: &str) -> &str {
     // Get the filename from the path
     let filename = path.rsplit('/').next().unwrap_or(path);
     // Also handle Windows-style paths

--- a/crates/flowscope-core/src/analyzer/transform.rs
+++ b/crates/flowscope-core/src/analyzer/transform.rs
@@ -3,6 +3,7 @@
 //! This module provides functions to transform lineage graphs after analysis,
 //! such as filtering out certain node types while preserving connectivity.
 
+use super::context::DBT_MODEL_SINK_METADATA_KEY;
 use crate::types::{Edge, EdgeType, NodeType, StatementLineage};
 use std::collections::{HashMap, HashSet};
 
@@ -22,7 +23,14 @@ pub fn filter_cte_nodes(lineage: &mut StatementLineage) {
     let mut removable_ids: HashSet<String> = lineage
         .nodes
         .iter()
-        .filter(|n| n.node_type == NodeType::Cte)
+        .filter(|n| {
+            n.node_type == NodeType::Cte
+                && n.metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get(DBT_MODEL_SINK_METADATA_KEY))
+                    .and_then(serde_json::Value::as_bool)
+                    != Some(true)
+        })
         .map(|n| n.id.as_ref().to_string())
         .collect();
 

--- a/crates/flowscope-core/src/analyzer/visitor.rs
+++ b/crates/flowscope-core/src/analyzer/visitor.rs
@@ -625,8 +625,8 @@ impl<'a, 'b> Visitor for LineageVisitor<'a, 'b> {
             self.visit_table_with_joins(table_with_joins);
         }
         if self.analyzer.column_lineage_enabled {
-            let output_node = self.ctx.output_node_id().map(|node_id| node_id.to_string());
-            let target_node = self.target_node.clone().or(output_node);
+            let sink_node = self.ctx.sink_node_id().map(|node_id| node_id.to_string());
+            let target_node = self.target_node.clone().or(sink_node);
             let mut select_analyzer = SelectAnalyzer::new(self.analyzer, self.ctx, target_node);
             select_analyzer.analyze(select);
         }

--- a/crates/flowscope-core/tests/templating.rs
+++ b/crates/flowscope-core/tests/templating.rs
@@ -1525,30 +1525,32 @@ GROUP BY customer_id
         "Should have cross-statement edges linking stg_orders to orders_summary"
     );
 
-    // The first statement's output should be labeled with the model name
+    // The first statement's sink should be materialized as the model's
+    // canonical Table node (issue #32) so it unifies with consumer
+    // references.
     let first_stmt = result
         .statements
         .first()
         .expect("Should have first statement");
-    let output_node = result
+    let sink_node = result
         .nodes_in_statement(first_stmt.statement_index)
-        .find(|n| n.node_type == NodeType::Output);
+        .find(|n| n.node_type.is_table_like() && n.label.as_ref() == "stg_orders");
 
     assert!(
-        output_node.is_some(),
-        "First statement should have an output node"
+        sink_node.is_some(),
+        "First statement should have a table sink for the dbt model"
     );
 
-    let output = output_node.unwrap();
+    let sink = sink_node.unwrap();
     assert_eq!(
-        output.label.as_ref(),
-        "stg_orders",
-        "Output node label should be the model name"
+        sink.node_type,
+        NodeType::Table,
+        "dbt model sink should be materialized as a Table, not an Output"
     );
     assert_eq!(
-        output.qualified_name.as_ref().map(|s| s.as_ref()),
+        sink.qualified_name.as_ref().map(|s| s.as_ref()),
         Some("stg_orders"),
-        "Output node qualified_name should be the model name"
+        "Model sink qualified_name should be the model name"
     );
 }
 
@@ -1611,19 +1613,28 @@ FROM scoped_data
         "dbt model-local CTEs should remain statement-local"
     );
 
-    let output_labels: Vec<_> = result
+    // Each dbt model's sink is materialized as a Table node labeled with the
+    // model name (see issue #32).
+    let sink_labels: Vec<_> = result
         .statements
         .iter()
         .filter_map(|statement| {
             result
                 .nodes_in_statement(statement.statement_index)
-                .find(|node| node.node_type == NodeType::Output)
+                .find(|node| {
+                    node.node_type.is_table_like()
+                        && node
+                            .qualified_name
+                            .as_ref()
+                            .map(|q| q.as_ref() == node.label.as_ref())
+                            .unwrap_or(false)
+                })
                 .map(|node| node.label.to_string())
         })
         .collect();
 
     assert_eq!(
-        output_labels,
+        sink_labels,
         vec!["customers".to_string(), "orders".to_string()]
     );
 }
@@ -1737,16 +1748,161 @@ fn dbt_model_name_extraction_from_path() {
         content: model.to_string(),
     }]);
 
-    let output_node = result.statements.first().and_then(|s| {
+    // The model sink is now a Table node keyed by the extracted model name
+    // (issue #32).
+    let sink_node = result.statements.first().and_then(|s| {
         result
             .nodes_in_statement(s.statement_index)
-            .find(|n| n.node_type == NodeType::Output)
+            .find(|n| n.node_type.is_table_like() && n.label.as_ref() == "stg_customers")
     });
 
-    assert!(output_node.is_some(), "Should have output node");
+    assert!(sink_node.is_some(), "Should have model sink node");
     assert_eq!(
-        output_node.unwrap().label.as_ref(),
+        sink_node.unwrap().label.as_ref(),
         "stg_customers",
         "Should extract 'stg_customers' from 'models/staging/stg_customers.sql'"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn dbt_chained_models_unify_producer_and_consumer_nodes() {
+    // Regression test for https://github.com/pondpilot/flowscope/issues/32.
+    //
+    // Each dbt .sql file is a model that materializes a table with the same name as
+    // the file. A downstream file references that table via `{{ ref(...) }}`. In the
+    // lineage graph the producing model and every `ref()` consumer must collapse
+    // into a single node for that table, so multi-hop chains (A -> B -> C) render
+    // as a single connected lineage rather than three disconnected fragments.
+    let stg_supplies = "select id, name, price from {{ source('raw', 'supplies') }}";
+    let int_supplies = "select id, upper(name) as name, price from {{ ref('stg_supplies') }}";
+    let fct_supplies =
+        "select id, name, price * 1.1 as price_with_tax from {{ ref('int_supplies') }}";
+
+    let result = analyze_dbt_files(vec![
+        FileSource {
+            name: "models/stg_supplies.sql".to_string(),
+            content: stg_supplies.to_string(),
+        },
+        FileSource {
+            name: "models/int_supplies.sql".to_string(),
+            content: int_supplies.to_string(),
+        },
+        FileSource {
+            name: "models/fct_supplies.sql".to_string(),
+            content: fct_supplies.to_string(),
+        },
+    ]);
+
+    assert!(
+        !result.summary.has_errors,
+        "dbt chain analysis should succeed: {:?}",
+        result.issues
+    );
+
+    // Each model name must appear as exactly one table-like node in the merged
+    // graph. Before the fix, the producer emitted an `Output` node and the
+    // consumer emitted a separate `Table` node with the same canonical name,
+    // so each model name collided into two distinct nodes.
+    for model in ["stg_supplies", "int_supplies", "fct_supplies"] {
+        let table_like_nodes: Vec<_> = result
+            .nodes
+            .iter()
+            .filter(|n| {
+                n.node_type.is_table_like()
+                    && n.canonical_name
+                        .as_ref()
+                        .map(|c| c.name.as_str() == model)
+                        .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(
+            table_like_nodes.len(),
+            1,
+            "model '{model}' should have exactly one unified table node, found {}: {:?}",
+            table_like_nodes.len(),
+            table_like_nodes
+        );
+
+        // The unified node should also not coexist with a dangling Output node
+        // labeled with the same model name.
+        let stray_output = result
+            .nodes
+            .iter()
+            .find(|n| n.node_type == NodeType::Output && n.label.as_ref() == model);
+        assert!(
+            stray_output.is_none(),
+            "model '{model}' should not have a leftover Output-typed node: {:?}",
+            stray_output
+        );
+    }
+
+    // The producer statement and the consumer statement must both reference the
+    // unified node — that's how downstream tools (mermaid export, column
+    // lineage, etc.) know A feeds B.
+    let stg_node = result
+        .nodes
+        .iter()
+        .find(|n| {
+            n.node_type.is_table_like()
+                && n.canonical_name
+                    .as_ref()
+                    .map(|c| c.name.as_str() == "stg_supplies")
+                    .unwrap_or(false)
+        })
+        .expect("stg_supplies unified node should exist");
+    assert!(
+        stg_node.statement_ids.contains(&0) && stg_node.statement_ids.contains(&1),
+        "unified stg_supplies node should be referenced by both producer (stmt 0) and \
+         consumer (stmt 1): statement_ids = {:?}",
+        stg_node.statement_ids
+    );
+
+    // A multi-hop cross-statement edge chain must exist: a cross-statement edge
+    // linking the producer of each model to its consumer.
+    let cross_edges: Vec<_> = result
+        .edges
+        .iter()
+        .filter(|e| e.edge_type == EdgeType::CrossStatement)
+        .collect();
+    // stg produced by 0 -> consumed by 1; int produced by 1 -> consumed by 2.
+    let has_stg_edge = cross_edges
+        .iter()
+        .any(|e| e.statement_ids == vec![0usize, 1usize]);
+    let has_int_edge = cross_edges
+        .iter()
+        .any(|e| e.statement_ids == vec![1usize, 2usize]);
+    assert!(
+        has_stg_edge && has_int_edge,
+        "should have cross-statement edges for stg (0->1) and int (1->2), got {:?}",
+        cross_edges
+            .iter()
+            .map(|e| &e.statement_ids)
+            .collect::<Vec<_>>()
+    );
+
+    // Table-level DataFlow edges should connect the models, matching the
+    // arrows produced by CTAS (`CREATE TABLE x AS SELECT ... FROM y`). Without
+    // these, the mermaid table view would show disconnected boxes even though
+    // the nodes unify correctly.
+    let int_node_id = result
+        .nodes
+        .iter()
+        .find(|n| {
+            n.node_type.is_table_like()
+                && n.canonical_name
+                    .as_ref()
+                    .map(|c| c.name.as_str() == "int_supplies")
+                    .unwrap_or(false)
+        })
+        .map(|n| n.id.clone())
+        .expect("int_supplies unified node should exist");
+    let has_stg_to_int = result
+        .edges
+        .iter()
+        .any(|e| e.edge_type == EdgeType::DataFlow && e.from == stg_node.id && e.to == int_node_id);
+    assert!(
+        has_stg_to_int,
+        "should have a DataFlow edge stg_supplies -> int_supplies at the table level"
     );
 }

--- a/crates/flowscope-core/tests/templating.rs
+++ b/crates/flowscope-core/tests/templating.rs
@@ -26,11 +26,11 @@ fn analyze_with_template(
     analyze(&request)
 }
 
-/// Helper to check if a table with the given name exists in the result.
+/// Helper to check if a persistent relation with the given name exists in the result.
 /// Checks both the label and qualified_name fields.
 fn has_table(result: &flowscope_core::AnalyzeResult, table_name: &str) -> bool {
     result.nodes.iter().any(|node| {
-        if node.node_type != NodeType::Table {
+        if !matches!(node.node_type, NodeType::Table | NodeType::View) {
             return false;
         }
         // Check label first
@@ -1526,8 +1526,8 @@ GROUP BY customer_id
     );
 
     // The first statement's sink should be materialized as the model's
-    // canonical Table node (issue #32) so it unifies with consumer
-    // references.
+    // canonical relation node (issue #32) so it unifies with consumer
+    // references while preserving the configured relation type.
     let first_stmt = result
         .statements
         .first()
@@ -1544,8 +1544,8 @@ GROUP BY customer_id
     let sink = sink_node.unwrap();
     assert_eq!(
         sink.node_type,
-        NodeType::Table,
-        "dbt model sink should be materialized as a Table, not an Output"
+        NodeType::View,
+        "dbt model sink should preserve the dbt materialized='view' relation type"
     );
     assert_eq!(
         sink.qualified_name.as_ref().map(|s| s.as_ref()),
@@ -1761,6 +1761,90 @@ fn dbt_model_name_extraction_from_path() {
         sink_node.unwrap().label.as_ref(),
         "stg_customers",
         "Should extract 'stg_customers' from 'models/staging/stg_customers.sql'"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn dbt_view_models_materialize_as_view_nodes() {
+    let model = r#"
+{{ config(materialized='view') }}
+SELECT 1 AS id
+"#;
+
+    let result = analyze_dbt_files(vec![FileSource {
+        name: "models/marts/orders_view.sql".to_string(),
+        content: model.to_string(),
+    }]);
+
+    let sink_node = result.statements.first().and_then(|statement| {
+        result
+            .nodes_in_statement(statement.statement_index)
+            .find(|node| {
+                node.label.as_ref() == "orders_view"
+                    && matches!(node.node_type, NodeType::Table | NodeType::View)
+            })
+    });
+
+    let sink_node = sink_node.expect("dbt view model should produce a sink node");
+    assert_eq!(
+        sink_node.node_type,
+        NodeType::View,
+        "dbt models configured as materialized='view' should surface as View nodes"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn dbt_merged_model_node_keeps_producer_occurrence_metadata() {
+    let producer = "SELECT 1 AS id";
+    let consumer = "SELECT * FROM {{ ref('stg_constants') }}";
+
+    let result = analyze_dbt_files(vec![
+        FileSource {
+            name: "models/stg_constants.sql".to_string(),
+            content: producer.to_string(),
+        },
+        FileSource {
+            name: "models/fct_constants.sql".to_string(),
+            content: consumer.to_string(),
+        },
+    ]);
+
+    let node = result
+        .nodes
+        .iter()
+        .find(|node| {
+            node.node_type.is_table_like()
+                && node
+                    .canonical_name
+                    .as_ref()
+                    .map(|canonical| canonical.name.as_str() == "stg_constants")
+                    .unwrap_or(false)
+        })
+        .expect("merged stg_constants node should exist");
+
+    let occurrence_source_names = node
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("occurrenceSourceNames"))
+        .and_then(serde_json::Value::as_array)
+        .expect("merged node should record occurrence source names");
+
+    assert!(
+        node.all_name_spans().len() >= 2,
+        "merged node should keep both the producer definition span and consumer ref span"
+    );
+    assert_eq!(
+        occurrence_source_names.first().and_then(serde_json::Value::as_str),
+        Some("models/stg_constants.sql"),
+        "producer file should be the first occurrence so graph reveal navigates to the model definition"
+    );
+    assert!(
+        occurrence_source_names
+            .iter()
+            .any(|value| value.as_str() == Some("models/fct_constants.sql")),
+        "consumer ref occurrences should still be retained on the merged node"
     );
 }
 

--- a/crates/flowscope-core/tests/templating.rs
+++ b/crates/flowscope-core/tests/templating.rs
@@ -922,7 +922,9 @@ fn dbt_snapshot_block_content_preserved() {
 //   - marts: customers, orders, daily_revenue
 
 #[cfg(feature = "templating")]
-use flowscope_core::{ColumnSchema, EdgeType, FileSource, SchemaMetadata, SchemaTable};
+use flowscope_core::{
+    AnalysisOptions, ColumnSchema, EdgeType, FileSource, SchemaMetadata, SchemaTable,
+};
 
 /// Helper to run multi-file dbt analysis.
 #[cfg(feature = "templating")]
@@ -1882,6 +1884,56 @@ SELECT 1 AS id
                     .unwrap_or(false))
         }),
         "ephemeral dbt models must not surface as persisted table/view nodes"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn hide_ctes_keeps_dbt_ephemeral_model_sinks() {
+    let request = AnalyzeRequest {
+        sql: String::new(),
+        files: Some(vec![
+            FileSource {
+                name: "models/consumer.sql".to_string(),
+                content: "WITH local_cte AS (SELECT 1 AS id) SELECT * FROM local_cte CROSS JOIN {{ ref('ephemeral_orders') }}".to_string(),
+            },
+            FileSource {
+                name: "models/ephemeral_orders.sql".to_string(),
+                content: "{{ config(materialized='ephemeral') }} SELECT 1 AS id".to_string(),
+            },
+        ]),
+        dialect: Dialect::Postgres,
+        source_name: None,
+        options: Some(AnalysisOptions {
+            hide_ctes: Some(true),
+            ..AnalysisOptions::default()
+        }),
+        schema: None,
+        template_config: Some(TemplateConfig {
+            mode: TemplateMode::Dbt,
+            context: HashMap::new(),
+        }),
+    };
+
+    let result = analyze(&request);
+
+    assert!(
+        result.nodes.iter().any(|node| {
+            node.node_type == NodeType::Cte
+                && node
+                    .canonical_name
+                    .as_ref()
+                    .map(|canonical| canonical.name.as_str() == "ephemeral_orders")
+                    .unwrap_or(false)
+        }),
+        "hide_ctes should preserve dbt ephemeral model sinks in the global graph"
+    );
+    assert!(
+        result
+            .nodes
+            .iter()
+            .all(|node| node.label.as_ref() != "local_cte"),
+        "hide_ctes should still remove statement-local CTEs"
     );
 }
 

--- a/crates/flowscope-core/tests/templating.rs
+++ b/crates/flowscope-core/tests/templating.rs
@@ -922,9 +922,7 @@ fn dbt_snapshot_block_content_preserved() {
 //   - marts: customers, orders, daily_revenue
 
 #[cfg(feature = "templating")]
-use flowscope_core::{
-    ColumnSchema, EdgeType, FileSource, ResolutionSource, SchemaMetadata, SchemaTable,
-};
+use flowscope_core::{ColumnSchema, EdgeType, FileSource, SchemaMetadata, SchemaTable};
 
 /// Helper to run multi-file dbt analysis.
 #[cfg(feature = "templating")]
@@ -1829,6 +1827,66 @@ SELECT 1 AS id
 
 #[test]
 #[cfg(feature = "templating")]
+fn dbt_ephemeral_models_surface_as_cte_nodes_instead_of_persistent_relations() {
+    let consumer = "SELECT * FROM {{ ref('ephemeral_orders') }}";
+    let producer = r#"
+{{ config(materialized='ephemeral') }}
+SELECT 1 AS id
+"#;
+
+    let result = analyze_dbt_files(vec![
+        FileSource {
+            name: "models/consumer.sql".to_string(),
+            content: consumer.to_string(),
+        },
+        FileSource {
+            name: "models/ephemeral_orders.sql".to_string(),
+            content: producer.to_string(),
+        },
+    ]);
+
+    let ephemeral_nodes: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.canonical_name
+                .as_ref()
+                .map(|canonical| canonical.name.as_str() == "ephemeral_orders")
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        ephemeral_nodes.len(),
+        1,
+        "ephemeral dbt models should collapse producer and consumer refs onto one node"
+    );
+
+    let ephemeral_node = ephemeral_nodes[0];
+    assert_eq!(
+        ephemeral_node.node_type,
+        NodeType::Cte,
+        "ephemeral dbt models should be represented as CTE-like nodes, not persisted relations"
+    );
+    assert!(
+        ephemeral_node.statement_ids.contains(&0) && ephemeral_node.statement_ids.contains(&1),
+        "the shared ephemeral node should be referenced by both the consumer and producer"
+    );
+    assert!(
+        result.nodes.iter().all(|node| {
+            !(matches!(node.node_type, NodeType::Table | NodeType::View)
+                && node
+                    .canonical_name
+                    .as_ref()
+                    .map(|canonical| canonical.name.as_str() == "ephemeral_orders")
+                    .unwrap_or(false))
+        }),
+        "ephemeral dbt models must not surface as persisted table/view nodes"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
 fn dbt_view_model_unifies_with_consumer_even_when_consumer_is_analyzed_first() {
     let consumer = "SELECT * FROM {{ ref('orders_view') }}";
     let producer = r#"
@@ -1947,7 +2005,6 @@ fn dbt_forward_ref_to_model_does_not_remain_unresolved() {
         .unwrap_or(false);
 
     assert_eq!(producer.resolution_source, None);
-    assert_ne!(producer.resolution_source, Some(ResolutionSource::Unknown));
     assert!(
         !has_placeholder,
         "producer node should not retain unresolved placeholder metadata once its model file is known"
@@ -2005,6 +2062,61 @@ fn dbt_merged_model_node_keeps_producer_occurrence_metadata() {
             .iter()
             .any(|value| value.as_str() == Some("models/fct_constants.sql")),
         "consumer ref occurrences should still be retained on the merged node"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn dbt_consumer_first_node_marks_producer_definition_occurrence() {
+    let consumer = "SELECT * FROM {{ ref('stg_constants') }}";
+    let producer = "SELECT 1 AS id";
+
+    let result = analyze_dbt_files(vec![
+        FileSource {
+            name: "models/fct_constants.sql".to_string(),
+            content: consumer.to_string(),
+        },
+        FileSource {
+            name: "models/stg_constants.sql".to_string(),
+            content: producer.to_string(),
+        },
+    ]);
+
+    let node = result
+        .nodes
+        .iter()
+        .find(|node| {
+            node.node_type.is_table_like()
+                && node
+                    .canonical_name
+                    .as_ref()
+                    .map(|canonical| canonical.name.as_str() == "stg_constants")
+                    .unwrap_or(false)
+        })
+        .expect("merged stg_constants node should exist");
+
+    let occurrence_source_names = node
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("occurrenceSourceNames"))
+        .and_then(serde_json::Value::as_array)
+        .expect("merged node should record occurrence source names");
+    let definition_source_names = node
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("definitionOccurrenceSourceNames"))
+        .and_then(serde_json::Value::as_array)
+        .expect("merged node should record producer-definition occurrences");
+
+    assert_eq!(
+        occurrence_source_names.first().and_then(serde_json::Value::as_str),
+        Some("models/fct_constants.sql"),
+        "raw occurrence order should still reflect analysis/file order when the consumer appears first"
+    );
+    assert_eq!(
+        definition_source_names.first().and_then(serde_json::Value::as_str),
+        Some("models/stg_constants.sql"),
+        "producer-definition metadata should identify the model file even when a consumer was analyzed first"
     );
 }
 

--- a/crates/flowscope-core/tests/templating.rs
+++ b/crates/flowscope-core/tests/templating.rs
@@ -922,7 +922,9 @@ fn dbt_snapshot_block_content_preserved() {
 //   - marts: customers, orders, daily_revenue
 
 #[cfg(feature = "templating")]
-use flowscope_core::{EdgeType, FileSource};
+use flowscope_core::{
+    ColumnSchema, EdgeType, FileSource, ResolutionSource, SchemaMetadata, SchemaTable,
+};
 
 /// Helper to run multi-file dbt analysis.
 #[cfg(feature = "templating")]
@@ -1796,6 +1798,37 @@ SELECT 1 AS id
 
 #[test]
 #[cfg(feature = "templating")]
+fn dbt_later_config_call_controls_materialization() {
+    let model = r#"
+{{ config(tags=['daily']) }}
+{{ config(materialized='view') }}
+SELECT 1 AS id
+"#;
+
+    let result = analyze_dbt_files(vec![FileSource {
+        name: "models/orders_view.sql".to_string(),
+        content: model.to_string(),
+    }]);
+
+    let sink_node = result.statements.first().and_then(|statement| {
+        result
+            .nodes_in_statement(statement.statement_index)
+            .find(|node| {
+                node.label.as_ref() == "orders_view"
+                    && matches!(node.node_type, NodeType::Table | NodeType::View)
+            })
+    });
+
+    let sink_node = sink_node.expect("dbt model should produce a sink node");
+    assert_eq!(
+        sink_node.node_type,
+        NodeType::View,
+        "a later config(materialized=...) call should control the dbt sink relation type"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
 fn dbt_view_model_unifies_with_consumer_even_when_consumer_is_analyzed_first() {
     let consumer = "SELECT * FROM {{ ref('orders_view') }}";
     let producer = r#"
@@ -1841,6 +1874,83 @@ SELECT 1 AS id
     assert!(
         orders_view.statement_ids.contains(&0) && orders_view.statement_ids.contains(&1),
         "unified orders_view node should be referenced by both the consumer and producer"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn dbt_forward_ref_to_model_does_not_remain_unresolved() {
+    let request = AnalyzeRequest {
+        sql: String::new(),
+        files: Some(vec![
+            FileSource {
+                name: "models/consumer.sql".to_string(),
+                content: "SELECT * FROM {{ ref('producer') }}".to_string(),
+            },
+            FileSource {
+                name: "models/producer.sql".to_string(),
+                content: "SELECT id FROM {{ source('raw', 'events') }}".to_string(),
+            },
+        ]),
+        dialect: Dialect::Postgres,
+        source_name: None,
+        options: None,
+        schema: Some(SchemaMetadata {
+            tables: vec![SchemaTable {
+                catalog: None,
+                schema: Some("raw".to_string()),
+                name: "events".to_string(),
+                columns: vec![ColumnSchema {
+                    name: "id".to_string(),
+                    data_type: Some("int".to_string()),
+                    is_primary_key: None,
+                    foreign_key: None,
+                }],
+            }],
+            ..SchemaMetadata::default()
+        }),
+        template_config: Some(TemplateConfig {
+            mode: TemplateMode::Dbt,
+            context: HashMap::new(),
+        }),
+    };
+
+    let result = analyze(&request);
+
+    assert!(
+        !result.issues.iter().any(|issue| {
+            issue.code == flowscope_core::issue_codes::UNRESOLVED_REFERENCE
+                && issue.message.contains("producer")
+        }),
+        "dbt model refs should be predeclared so forward references do not stay unresolved: {:?}",
+        result.issues
+    );
+
+    let producer = result
+        .nodes
+        .iter()
+        .find(|node| {
+            node.node_type.is_table_like()
+                && node
+                    .canonical_name
+                    .as_ref()
+                    .map(|canonical| canonical.name.as_str() == "producer")
+                    .unwrap_or(false)
+        })
+        .expect("producer node should exist");
+
+    let has_placeholder = producer
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("placeholder"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    assert_eq!(producer.resolution_source, None);
+    assert_ne!(producer.resolution_source, Some(ResolutionSource::Unknown));
+    assert!(
+        !has_placeholder,
+        "producer node should not retain unresolved placeholder metadata once its model file is known"
     );
 }
 

--- a/crates/flowscope-core/tests/templating.rs
+++ b/crates/flowscope-core/tests/templating.rs
@@ -1796,6 +1796,56 @@ SELECT 1 AS id
 
 #[test]
 #[cfg(feature = "templating")]
+fn dbt_view_model_unifies_with_consumer_even_when_consumer_is_analyzed_first() {
+    let consumer = "SELECT * FROM {{ ref('orders_view') }}";
+    let producer = r#"
+{{ config(materialized='view') }}
+SELECT 1 AS id
+"#;
+
+    let result = analyze_dbt_files(vec![
+        FileSource {
+            name: "models/fct_orders.sql".to_string(),
+            content: consumer.to_string(),
+        },
+        FileSource {
+            name: "models/orders_view.sql".to_string(),
+            content: producer.to_string(),
+        },
+    ]);
+
+    let orders_view_nodes: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.node_type.is_table_like()
+                && node
+                    .canonical_name
+                    .as_ref()
+                    .map(|canonical| canonical.name.as_str() == "orders_view")
+                    .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        orders_view_nodes.len(),
+        1,
+        "consumer and producer should collapse into one canonical orders_view node"
+    );
+    let orders_view = orders_view_nodes[0];
+    assert_eq!(
+        orders_view.node_type,
+        NodeType::View,
+        "future dbt view producers should predeclare a view identity for earlier consumers"
+    );
+    assert!(
+        orders_view.statement_ids.contains(&0) && orders_view.statement_ids.contains(&1),
+        "unified orders_view node should be referenced by both the consumer and producer"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
 fn dbt_merged_model_node_keeps_producer_occurrence_metadata() {
     let producer = "SELECT 1 AS id";
     let consumer = "SELECT * FROM {{ ref('stg_constants') }}";

--- a/packages/react/src/utils/graphBuilders.ts
+++ b/packages/react/src/utils/graphBuilders.ts
@@ -23,6 +23,7 @@ import {
   syntheticEdgeId,
   isNodeHighlighted,
   createStatementScope,
+  isScriptRelationNode,
   withStatementScope,
 } from './lineageHelpers';
 import { mergeNodesForNavigation, scopeNodeToStatement } from './nodeOccurrences';
@@ -850,7 +851,7 @@ function getScriptIO(slices: StatementSlice[]) {
         return;
       }
 
-      if (node.type === 'table' || node.type === 'view') {
+      if (isScriptRelationNode(node)) {
         const isWritten =
           slice.edges.some((e) => e.to === node.id && e.type === 'data_flow') ||
           createdRelationIds.has(node.id);
@@ -950,7 +951,7 @@ function buildHybridGraph(
           return;
         }
 
-        if (node.type === 'table' || node.type === 'view') {
+        if (isScriptRelationNode(node)) {
           const qName = node.qualifiedName || node.label;
           const isWritten =
             slice.edges.some((e) => e.to === node.id && e.type === 'data_flow') ||

--- a/packages/react/src/utils/lineageHelpers.ts
+++ b/packages/react/src/utils/lineageHelpers.ts
@@ -34,6 +34,18 @@ function isRelationNode(node: Node): node is RelationNode {
  *
  * "Non-ownership" means edges whose type is not `ownership`, i.e. data_flow,
  * derivation, join_dependency, or cross_statement.
+ *
+ * @example
+ * // `CREATE TABLE sink AS SELECT src.id FROM src` —
+ * // sink.id has one incoming data_flow from src.id (incoming=1, outgoing=0),
+ * // src.id has one outgoing data_flow and nothing incoming (incoming=0, outgoing=1).
+ * isCreatedProjectionColumn('col:sink.id', …)  // → true  (projection)
+ * isCreatedProjectionColumn('col:src.id',  …)  // → false (source column)
+ *
+ * @example
+ * // Bare dbt SELECT: `SELECT 1 AS id` with no lineage edges.
+ * // sink.id has neither incoming nor outgoing non-ownership edges.
+ * isCreatedProjectionColumn('col:sink.id', …)  // → true  (constant projection)
  */
 function isCreatedProjectionColumn(
   columnId: string,

--- a/packages/react/src/utils/lineageHelpers.ts
+++ b/packages/react/src/utils/lineageHelpers.ts
@@ -13,11 +13,27 @@ function isRelationNode(node: Node): node is RelationNode {
 }
 
 /**
- * A column owned by a relation node is a statement-local projection when it
- * either has at least one non-ownership incoming edge (fed by intra-statement
- * flows) or has no non-ownership edges at all (e.g., `SELECT 1 AS id`).
- * Source-table columns are excluded because they only carry outgoing flow
- * edges — they feed the projection rather than being produced by it.
+ * True when a relation-owned column looks like a statement-local projection
+ * (a "written" column of this statement) rather than a source-table column
+ * that merely feeds one.
+ *
+ * Decision rule, applied to a single column id:
+ *
+ *   - `incoming > 0`                       → projection. At least one
+ *     non-ownership edge lands on it, which only happens for columns that
+ *     receive data within this statement (e.g., `sink.col` being filled from
+ *     a source column).
+ *   - `incoming === 0 && outgoing === 0`   → projection. No flow touches it
+ *     in either direction, which matches constant projections like
+ *     `SELECT 1 AS id` and dbt bare-SELECT model outputs whose column
+ *     lineage hasn't produced non-ownership edges.
+ *   - `incoming === 0 && outgoing > 0`     → NOT a projection. A column with
+ *     only outgoing flow edges is a source-table column feeding a downstream
+ *     projection; marking it as "created" would falsely attribute the source
+ *     table as the statement's written relation.
+ *
+ * "Non-ownership" means edges whose type is not `ownership`, i.e. data_flow,
+ * derivation, join_dependency, or cross_statement.
  */
 function isCreatedProjectionColumn(
   columnId: string,
@@ -63,18 +79,31 @@ const DEFAULT_STATEMENT_SCOPE = 'statement:0';
 const STATEMENT_SCOPE_METADATA_KEY = 'statementScope';
 
 /**
- * Returns the node ids for relations created by a statement (e.g. CREATE TABLE/VIEW).
- * For CREATE statements we prefer nodes that receive data_flow edges; when lineage
- * does not include explicit flows (simple CREATE TABLE), we fall back to the sole
- * relation node or one that matches the statement type. dbt bare-SELECT model sinks
- * are also treated as created relations when a table/view owns statement-local
- * projection columns. We identify those columns from the statement's edge shape
- * instead of `qualifiedName` because flattened column nodes may inherit a
- * qualified name from another statement after producer/consumer merging.
+ * Returns the node ids of relations written by a statement.
  *
- * Operates on a per-statement view of the flat `AnalyzeResult`: pass the statement
- * type together with the nodes and edges that participate in that statement
- * (see `nodesInStatement` / `edgesInStatement`).
+ * "Written" here is broader than `CREATE TABLE` / `CREATE VIEW`: the function
+ * also flags dbt bare-SELECT model sinks (whose lineage shape is a relation
+ * owning statement-local projection columns, with no `CREATE_*` statement
+ * type) and any DML that surfaces as a relation receiving projection columns.
+ * If a consumer only cares about strict CREATE semantics, it must additionally
+ * check `statementType`.
+ *
+ * Algorithm:
+ *   1. Scan ownership edges. Any relation that owns a column classified by
+ *      {@link isCreatedProjectionColumn} is treated as written by this
+ *      statement. This picks up dbt model sinks and CREATE TABLE AS SELECT
+ *      alike, and is robust to column-node merging: projection columns are
+ *      identified by edge shape rather than by `qualifiedName`, which may be
+ *      inherited from another statement after flattening.
+ *   2. Scan data_flow edges into relation nodes. This captures the legacy
+ *      CREATE path where the sink is identified only by an incoming data flow.
+ *   3. If neither path produced a result and the statement is `CREATE_*`,
+ *      fall back to a sole relation node or one matching the statement's
+ *      target type (`table` for CREATE_TABLE*, `view` for CREATE_VIEW).
+ *
+ * Operates on a per-statement view of the flat `AnalyzeResult`: pass the
+ * statement type together with the nodes and edges that participate in that
+ * statement (see `nodesInStatement` / `edgesInStatement`).
  */
 export function getCreatedRelationNodeIds(
   statementType: string,

--- a/packages/react/src/utils/lineageHelpers.ts
+++ b/packages/react/src/utils/lineageHelpers.ts
@@ -2,14 +2,19 @@ import type { Node, Edge, AggregationInfo } from '@pondpilot/flowscope-core';
 import { JOIN_TYPE_LABELS } from '../constants';
 
 const CREATE_STATEMENT_TYPES = new Set(['CREATE_TABLE', 'CREATE_TABLE_AS', 'CREATE_VIEW']);
+const DBT_MODEL_SINK_METADATA_KEY = 'dbtModelSink';
 
 /** Node type constant for output nodes. */
 export const OUTPUT_NODE_TYPE = 'output' as Node['type'];
 
-type RelationNode = Node & { type: 'table' | 'view' };
+type ScriptRelationNode = Node & { type: 'table' | 'view' | 'cte' };
 
-function isRelationNode(node: Node): node is RelationNode {
-  return node.type === 'table' || node.type === 'view';
+function isDbtEphemeralModelSink(node: Node): node is Node & { type: 'cte' } {
+  return node.type === 'cte' && node.metadata?.[DBT_MODEL_SINK_METADATA_KEY] === true;
+}
+
+export function isScriptRelationNode(node: Node): node is ScriptRelationNode {
+  return node.type === 'table' || node.type === 'view' || isDbtEphemeralModelSink(node);
 }
 
 /**
@@ -96,7 +101,9 @@ const STATEMENT_SCOPE_METADATA_KEY = 'statementScope';
  * "Written" here is broader than `CREATE TABLE` / `CREATE VIEW`: the function
  * also flags dbt bare-SELECT model sinks (whose lineage shape is a relation
  * owning statement-local projection columns, with no `CREATE_*` statement
- * type) and any DML that surfaces as a relation receiving projection columns.
+ * type), including dbt `materialized='ephemeral'` sinks that surface as
+ * metadata-marked `cte` nodes, and any DML that surfaces as a relation
+ * receiving projection columns.
  * If a consumer only cares about strict CREATE semantics, it must additionally
  * check `statementType`.
  *
@@ -122,7 +129,7 @@ export function getCreatedRelationNodeIds(
   nodes: Node[],
   edges: Edge[]
 ): Set<string> {
-  const relationNodes = nodes.filter(isRelationNode);
+  const relationNodes = nodes.filter(isScriptRelationNode);
   const relationNodeIds = new Set(relationNodes.map((n) => n.id));
   const columnNodeIds = new Set(nodes.filter((n) => n.type === 'column').map((node) => node.id));
   const incomingNonOwnershipCounts = new Map<string, number>();

--- a/packages/react/src/utils/lineageHelpers.ts
+++ b/packages/react/src/utils/lineageHelpers.ts
@@ -44,8 +44,10 @@ const STATEMENT_SCOPE_METADATA_KEY = 'statementScope';
  * For CREATE statements we prefer nodes that receive data_flow edges; when lineage
  * does not include explicit flows (simple CREATE TABLE), we fall back to the sole
  * relation node or one that matches the statement type. dbt bare-SELECT model sinks
- * are also treated as created relations when a table/view owns projected columns
- * with no qualified name.
+ * are also treated as created relations when a table/view owns statement-local
+ * projection columns. We identify those columns from the statement's edge shape
+ * instead of `qualifiedName` because flattened column nodes may inherit a
+ * qualified name from another statement after producer/consumer merging.
  *
  * Operates on a per-statement view of the flat `AnalyzeResult`: pass the statement
  * type together with the nodes and edges that participate in that statement
@@ -58,19 +60,32 @@ export function getCreatedRelationNodeIds(
 ): Set<string> {
   const relationNodes = nodes.filter((n) => n.type === 'table' || n.type === 'view');
   const relationNodeIds = new Set(relationNodes.map((n) => n.id));
-  const columnNodes = new Map(
-    nodes.filter((n) => n.type === 'column').map((node) => [node.id, node])
-  );
+  const columnNodeIds = new Set(nodes.filter((n) => n.type === 'column').map((node) => node.id));
+  const incomingNonOwnershipCounts = new Map<string, number>();
+  const outgoingNonOwnershipCounts = new Map<string, number>();
+
+  for (const edge of edges) {
+    if (edge.type === 'ownership') {
+      continue;
+    }
+
+    outgoingNonOwnershipCounts.set(edge.from, (outgoingNonOwnershipCounts.get(edge.from) ?? 0) + 1);
+    incomingNonOwnershipCounts.set(edge.to, (incomingNonOwnershipCounts.get(edge.to) ?? 0) + 1);
+  }
 
   const createdNodeIds = new Set<string>();
   for (const edge of edges) {
-    if (
-      edge.type === 'ownership' &&
-      relationNodeIds.has(edge.from) &&
-      !columnNodes.get(edge.to)?.qualifiedName
-    ) {
-      createdNodeIds.add(edge.from);
-      continue;
+    // Relation sinks own either projected columns fed by intra-statement flow
+    // edges, or isolated columns such as `SELECT 1 AS id` where the projection
+    // has no non-ownership edges at all. Source-table columns are only emitted
+    // as lineage inputs, so they have outgoing flow edges but no incoming ones.
+    if (edge.type === 'ownership' && relationNodeIds.has(edge.from) && columnNodeIds.has(edge.to)) {
+      const incoming = incomingNonOwnershipCounts.get(edge.to) ?? 0;
+      const outgoing = outgoingNonOwnershipCounts.get(edge.to) ?? 0;
+      if (incoming > 0 || (incoming === 0 && outgoing === 0)) {
+        createdNodeIds.add(edge.from);
+        continue;
+      }
     }
 
     if (edge.type === 'data_flow' && relationNodeIds.has(edge.to)) {

--- a/packages/react/src/utils/lineageHelpers.ts
+++ b/packages/react/src/utils/lineageHelpers.ts
@@ -6,6 +6,29 @@ const CREATE_STATEMENT_TYPES = new Set(['CREATE_TABLE', 'CREATE_TABLE_AS', 'CREA
 /** Node type constant for output nodes. */
 export const OUTPUT_NODE_TYPE = 'output' as Node['type'];
 
+type RelationNode = Node & { type: 'table' | 'view' };
+
+function isRelationNode(node: Node): node is RelationNode {
+  return node.type === 'table' || node.type === 'view';
+}
+
+/**
+ * A column owned by a relation node is a statement-local projection when it
+ * either has at least one non-ownership incoming edge (fed by intra-statement
+ * flows) or has no non-ownership edges at all (e.g., `SELECT 1 AS id`).
+ * Source-table columns are excluded because they only carry outgoing flow
+ * edges — they feed the projection rather than being produced by it.
+ */
+function isCreatedProjectionColumn(
+  columnId: string,
+  incomingNonOwnershipCounts: Map<string, number>,
+  outgoingNonOwnershipCounts: Map<string, number>
+): boolean {
+  const incoming = incomingNonOwnershipCounts.get(columnId) ?? 0;
+  const outgoing = outgoingNonOwnershipCounts.get(columnId) ?? 0;
+  return incoming > 0 || (incoming === 0 && outgoing === 0);
+}
+
 /**
  * React Flow node id used for table/view/output relations in the hybrid
  * script-plus-tables graph view. The id is built from the qualified name when
@@ -58,7 +81,7 @@ export function getCreatedRelationNodeIds(
   nodes: Node[],
   edges: Edge[]
 ): Set<string> {
-  const relationNodes = nodes.filter((n) => n.type === 'table' || n.type === 'view');
+  const relationNodes = nodes.filter(isRelationNode);
   const relationNodeIds = new Set(relationNodes.map((n) => n.id));
   const columnNodeIds = new Set(nodes.filter((n) => n.type === 'column').map((node) => node.id));
   const incomingNonOwnershipCounts = new Map<string, number>();
@@ -75,17 +98,14 @@ export function getCreatedRelationNodeIds(
 
   const createdNodeIds = new Set<string>();
   for (const edge of edges) {
-    // Relation sinks own either projected columns fed by intra-statement flow
-    // edges, or isolated columns such as `SELECT 1 AS id` where the projection
-    // has no non-ownership edges at all. Source-table columns are only emitted
-    // as lineage inputs, so they have outgoing flow edges but no incoming ones.
-    if (edge.type === 'ownership' && relationNodeIds.has(edge.from) && columnNodeIds.has(edge.to)) {
-      const incoming = incomingNonOwnershipCounts.get(edge.to) ?? 0;
-      const outgoing = outgoingNonOwnershipCounts.get(edge.to) ?? 0;
-      if (incoming > 0 || (incoming === 0 && outgoing === 0)) {
-        createdNodeIds.add(edge.from);
-        continue;
-      }
+    if (
+      edge.type === 'ownership' &&
+      relationNodeIds.has(edge.from) &&
+      columnNodeIds.has(edge.to) &&
+      isCreatedProjectionColumn(edge.to, incomingNonOwnershipCounts, outgoingNonOwnershipCounts)
+    ) {
+      createdNodeIds.add(edge.from);
+      continue;
     }
 
     if (edge.type === 'data_flow' && relationNodeIds.has(edge.to)) {

--- a/packages/react/src/utils/lineageHelpers.ts
+++ b/packages/react/src/utils/lineageHelpers.ts
@@ -43,7 +43,9 @@ const STATEMENT_SCOPE_METADATA_KEY = 'statementScope';
  * Returns the node ids for relations created by a statement (e.g. CREATE TABLE/VIEW).
  * For CREATE statements we prefer nodes that receive data_flow edges; when lineage
  * does not include explicit flows (simple CREATE TABLE), we fall back to the sole
- * relation node or one that matches the statement type.
+ * relation node or one that matches the statement type. dbt bare-SELECT model sinks
+ * are also treated as created relations when a table/view owns projected columns
+ * with no qualified name.
  *
  * Operates on a per-statement view of the flat `AnalyzeResult`: pass the statement
  * type together with the nodes and edges that participate in that statement
@@ -54,21 +56,33 @@ export function getCreatedRelationNodeIds(
   nodes: Node[],
   edges: Edge[]
 ): Set<string> {
-  if (!CREATE_STATEMENT_TYPES.has(statementType)) {
-    return new Set();
-  }
-
   const relationNodes = nodes.filter((n) => n.type === 'table' || n.type === 'view');
   const relationNodeIds = new Set(relationNodes.map((n) => n.id));
+  const columnNodes = new Map(
+    nodes.filter((n) => n.type === 'column').map((node) => [node.id, node])
+  );
 
   const createdNodeIds = new Set<string>();
   for (const edge of edges) {
+    if (
+      edge.type === 'ownership' &&
+      relationNodeIds.has(edge.from) &&
+      !columnNodes.get(edge.to)?.qualifiedName
+    ) {
+      createdNodeIds.add(edge.from);
+      continue;
+    }
+
     if (edge.type === 'data_flow' && relationNodeIds.has(edge.to)) {
       createdNodeIds.add(edge.to);
     }
   }
 
   if (createdNodeIds.size > 0) {
+    return createdNodeIds;
+  }
+
+  if (!CREATE_STATEMENT_TYPES.has(statementType)) {
     return createdNodeIds;
   }
 

--- a/packages/react/src/utils/matrixUtils.ts
+++ b/packages/react/src/utils/matrixUtils.ts
@@ -10,6 +10,7 @@ import {
   OUTPUT_NODE_TYPE,
   JOIN_DEPENDENCY_EDGE_TYPE,
   buildColumnOwnershipMap,
+  isScriptRelationNode,
 } from './lineageHelpers';
 import { getOccurrenceForStatement } from './nodeOccurrences';
 
@@ -181,7 +182,7 @@ export function extractScriptDependencies(result: AnalyzeResult): ScriptDependen
 
     const stmtNodes = nodesInStatement(result, stmt.statementIndex);
     const stmtEdges = edgesInStatement(result, stmt.statementIndex);
-    const tableNodes = stmtNodes.filter((n) => n.type === 'table' || n.type === 'view');
+    const tableNodes = stmtNodes.filter(isScriptRelationNode);
     const outputNodes = stmtNodes.filter((n) => n.type === OUTPUT_NODE_TYPE);
     const createdRelationIds = getCreatedRelationNodeIds(stmt.statementType, stmtNodes, stmtEdges);
 

--- a/packages/react/src/utils/nodeOccurrences.ts
+++ b/packages/react/src/utils/nodeOccurrences.ts
@@ -3,10 +3,20 @@ import type { AnalyzeResult, Node, Span, StatementMeta } from '@pondpilot/flowsc
 const OCCURRENCE_SPANS_METADATA_KEY = 'occurrenceSpans';
 const OCCURRENCE_STATEMENT_IDS_METADATA_KEY = 'occurrenceStatementIds';
 const OCCURRENCE_SOURCE_NAMES_METADATA_KEY = 'occurrenceSourceNames';
+const DEFINITION_OCCURRENCE_SPANS_METADATA_KEY = 'definitionOccurrenceSpans';
+const DEFINITION_OCCURRENCE_STATEMENT_IDS_METADATA_KEY = 'definitionOccurrenceStatementIds';
+const DEFINITION_OCCURRENCE_SOURCE_NAMES_METADATA_KEY = 'definitionOccurrenceSourceNames';
 const BODY_SPANS_METADATA_KEY = 'bodySpans';
 const BODY_STATEMENT_IDS_METADATA_KEY = 'bodyStatementIds';
 const BODY_SOURCE_NAMES_METADATA_KEY = 'bodySourceNames';
 const STATEMENT_AGGREGATIONS_METADATA_KEY = 'statementAggregations';
+
+interface OccurrenceEntry {
+  span: Span;
+  statementId: number | null;
+  sourceName: string | null;
+  isDefinition: boolean;
+}
 
 function isSpan(value: unknown): value is Span {
   return (
@@ -57,7 +67,7 @@ function getFallbackSourceName(node: Node, sourceName?: string): string | null {
   return sourceName ?? null;
 }
 
-function buildOccurrenceSpans(node: Node): Span[] {
+function getBaseOccurrenceSpans(node: Node): Span[] {
   const explicit = readSpanArray(node.metadata?.[OCCURRENCE_SPANS_METADATA_KEY]);
   if (explicit.length > 0) {
     return explicit;
@@ -68,13 +78,13 @@ function buildOccurrenceSpans(node: Node): Span[] {
   return node.span ? [node.span] : [];
 }
 
-function buildOccurrenceStatementIds(node: Node): number[] {
+function getBaseOccurrenceStatementIds(node: Node): number[] {
   const explicit = readNumberArray(node.metadata?.[OCCURRENCE_STATEMENT_IDS_METADATA_KEY]);
   if (explicit.length > 0) {
     return explicit;
   }
 
-  const occurrenceCount = buildOccurrenceSpans(node).length;
+  const occurrenceCount = getBaseOccurrenceSpans(node).length;
   if (occurrenceCount === 0) {
     return [];
   }
@@ -87,8 +97,8 @@ function buildOccurrenceStatementIds(node: Node): number[] {
   return [];
 }
 
-function buildOccurrenceSourceNames(node: Node, sourceName?: string): Array<string | null> {
-  const spanCount = buildOccurrenceSpans(node).length;
+function getBaseOccurrenceSourceNames(node: Node, sourceName?: string): Array<string | null> {
+  const spanCount = getBaseOccurrenceSpans(node).length;
   if (spanCount === 0) {
     return [];
   }
@@ -96,6 +106,68 @@ function buildOccurrenceSourceNames(node: Node, sourceName?: string): Array<stri
   const explicit = readSourceNameArray(node.metadata?.[OCCURRENCE_SOURCE_NAMES_METADATA_KEY]);
   const fallback = getFallbackSourceName(node, sourceName);
   return Array.from({ length: spanCount }, (_, index) => explicit[index] ?? fallback);
+}
+
+function buildOccurrenceEntries(node: Node, sourceName?: string): OccurrenceEntry[] {
+  const spans = getBaseOccurrenceSpans(node);
+  const statementIds = getBaseOccurrenceStatementIds(node);
+  const sourceNames = getBaseOccurrenceSourceNames(node, sourceName);
+
+  const definitionSpans = readSpanArray(node.metadata?.[DEFINITION_OCCURRENCE_SPANS_METADATA_KEY]);
+  const definitionStatementIds = readNumberArray(
+    node.metadata?.[DEFINITION_OCCURRENCE_STATEMENT_IDS_METADATA_KEY]
+  );
+  const definitionSourceNames = readSourceNameArray(
+    node.metadata?.[DEFINITION_OCCURRENCE_SOURCE_NAMES_METADATA_KEY]
+  );
+
+  const definitionKeys = new Set(
+    definitionSpans.map((span, index) =>
+      JSON.stringify({
+        start: span.start,
+        end: span.end,
+        statementId: definitionStatementIds[index] ?? null,
+        sourceName: definitionSourceNames[index] ?? null,
+      })
+    )
+  );
+
+  const entries = spans.map((span, index) => {
+    const statementId = statementIds[index] ?? null;
+    const resolvedSourceName = sourceNames[index] ?? null;
+    const key = JSON.stringify({
+      start: span.start,
+      end: span.end,
+      statementId,
+      sourceName: resolvedSourceName,
+    });
+
+    return {
+      span,
+      statementId,
+      sourceName: resolvedSourceName,
+      isDefinition: definitionKeys.has(key),
+    } satisfies OccurrenceEntry;
+  });
+
+  return entries.sort((left, right) => {
+    if (left.isDefinition !== right.isDefinition) {
+      return left.isDefinition ? -1 : 1;
+    }
+    return 0;
+  });
+}
+
+function buildOccurrenceSpans(node: Node, sourceName?: string): Span[] {
+  return buildOccurrenceEntries(node, sourceName).map((entry) => entry.span);
+}
+
+function buildOccurrenceStatementIds(node: Node, sourceName?: string): number[] {
+  return buildOccurrenceEntries(node, sourceName).map((entry) => entry.statementId ?? Number.NaN);
+}
+
+function buildOccurrenceSourceNames(node: Node, sourceName?: string): Array<string | null> {
+  return buildOccurrenceEntries(node, sourceName).map((entry) => entry.sourceName);
 }
 
 function buildBodySpans(node: Node): Span[] {

--- a/packages/react/src/workers/graphBuilder.worker.ts
+++ b/packages/react/src/workers/graphBuilder.worker.ts
@@ -27,6 +27,7 @@ import {
   syntheticEdgeId,
   isNodeHighlighted,
   createStatementScope,
+  isScriptRelationNode,
   withStatementScope,
 } from '../utils/lineageHelpers';
 import { mergeNodesForNavigation, scopeNodeToStatement } from '../utils/nodeOccurrences';
@@ -954,7 +955,7 @@ function getScriptIO(slices: StatementSlice[]) {
         return;
       }
 
-      if (node.type === 'table' || node.type === 'view') {
+      if (isScriptRelationNode(node)) {
         const isWritten =
           slice.edges.some((e) => e.to === node.id && e.type === 'data_flow') ||
           createdRelationIds.has(node.id);
@@ -1044,7 +1045,7 @@ function buildHybridGraph(
           return;
         }
 
-        if (node.type === 'table' || node.type === 'view') {
+        if (isScriptRelationNode(node)) {
           const qName = node.qualifiedName || node.label;
           const isWritten =
             slice.edges.some((e) => e.to === node.id && e.type === 'data_flow') ||

--- a/packages/react/tests/graphBuilders.test.ts
+++ b/packages/react/tests/graphBuilders.test.ts
@@ -1408,6 +1408,9 @@ describe('graphBuilders DML handling', () => {
             id: 'column:constants.id',
             type: 'column',
             label: 'id',
+            // Simulate a merged producer/consumer column node that picked up a
+            // source qualifiedName from another statement.
+            qualifiedName: 'constants.id',
           },
         ],
         edges: [

--- a/packages/react/tests/graphBuilders.test.ts
+++ b/packages/react/tests/graphBuilders.test.ts
@@ -1388,4 +1388,51 @@ describe('graphBuilders DML handling', () => {
       )
     ).toBeDefined();
   });
+
+  it('includes dbt relation sinks as written relations in script graph mode', () => {
+    const statements: TestStatement[] = [
+      {
+        statementIndex: 0,
+        statementType: 'SELECT',
+        sourceName: 'models/constants.sql',
+        joinCount: 0,
+        complexityScore: 1,
+        nodes: [
+          {
+            id: 'table:constants',
+            type: 'table',
+            label: 'constants',
+            qualifiedName: 'constants',
+          },
+          {
+            id: 'column:constants.id',
+            type: 'column',
+            label: 'id',
+          },
+        ],
+        edges: [
+          {
+            id: 'own:constants.id',
+            from: 'table:constants',
+            to: 'column:constants.id',
+            type: 'ownership',
+          },
+        ],
+      },
+    ];
+
+    const { nodes, edges } = buildScriptLevelGraph(toResult(statements), null, '', true);
+
+    expect(nodes.find((node) => node.id === 'table:constants')).toBeDefined();
+    expect(
+      edges.find(
+        (edge) => edge.source === 'script:models/constants.sql' && edge.target === 'table:constants'
+      )
+    ).toBeDefined();
+    expect(
+      edges.find(
+        (edge) => edge.source === 'table:constants' && edge.target === 'script:models/constants.sql'
+      )
+    ).toBeUndefined();
+  });
 });

--- a/packages/react/tests/graphBuilders.test.ts
+++ b/packages/react/tests/graphBuilders.test.ts
@@ -1438,4 +1438,57 @@ describe('graphBuilders DML handling', () => {
       )
     ).toBeUndefined();
   });
+
+  it('includes dbt ephemeral model sinks as written relations in script graph mode', () => {
+    const statements: TestStatement[] = [
+      {
+        statementIndex: 0,
+        statementType: 'SELECT',
+        sourceName: 'models/ephemeral_constants.sql',
+        joinCount: 0,
+        complexityScore: 1,
+        nodes: [
+          {
+            id: 'cte:ephemeral_constants',
+            type: 'cte',
+            label: 'ephemeral_constants',
+            qualifiedName: 'analytics.ephemeral_constants',
+            metadata: { dbtModelSink: true },
+          },
+          {
+            id: 'column:ephemeral_constants.id',
+            type: 'column',
+            label: 'id',
+            qualifiedName: 'analytics.ephemeral_constants.id',
+          },
+        ],
+        edges: [
+          {
+            id: 'own:ephemeral_constants.id',
+            from: 'cte:ephemeral_constants',
+            to: 'column:ephemeral_constants.id',
+            type: 'ownership',
+          },
+        ],
+      },
+    ];
+
+    const { nodes, edges } = buildScriptLevelGraph(toResult(statements), null, '', true);
+
+    expect(nodes.find((node) => node.id === 'table:analytics.ephemeral_constants')).toBeDefined();
+    expect(
+      edges.find(
+        (edge) =>
+          edge.source === 'script:models/ephemeral_constants.sql' &&
+          edge.target === 'table:analytics.ephemeral_constants'
+      )
+    ).toBeDefined();
+    expect(
+      edges.find(
+        (edge) =>
+          edge.source === 'table:analytics.ephemeral_constants' &&
+          edge.target === 'script:models/ephemeral_constants.sql'
+      )
+    ).toBeUndefined();
+  });
 });

--- a/packages/react/tests/matrixView.test.ts
+++ b/packages/react/tests/matrixView.test.ts
@@ -434,6 +434,9 @@ describe('extractScriptDependencies', () => {
             id: 'column:producer_model.id',
             type: 'column',
             label: 'id',
+            // Simulate a merged producer/consumer column node that inherited a
+            // source qualifiedName from another statement.
+            qualifiedName: 'analytics.producer_model.id',
           },
         ],
         edges: [

--- a/packages/react/tests/matrixView.test.ts
+++ b/packages/react/tests/matrixView.test.ts
@@ -480,6 +480,72 @@ describe('extractScriptDependencies', () => {
     expect(producerToConsumer).toBeDefined();
     expect(producerToConsumer!.sharedTables).toEqual(['analytics.producer_model']);
   });
+
+  it('treats dbt ephemeral model sinks as written relations for script dependencies', () => {
+    const statements: TestStatement[] = [
+      {
+        statementIndex: 0,
+        statementType: 'SELECT',
+        sourceName: 'producer.sql',
+        joinCount: 0,
+        complexityScore: 1,
+        nodes: [
+          {
+            id: 'cte:producer_model',
+            type: 'cte',
+            label: 'producer_model',
+            qualifiedName: 'analytics.producer_model',
+            metadata: { dbtModelSink: true },
+          },
+          {
+            id: 'column:producer_model.id',
+            type: 'column',
+            label: 'id',
+            qualifiedName: 'analytics.producer_model.id',
+          },
+        ],
+        edges: [
+          {
+            id: 'own:producer_model.id',
+            from: 'cte:producer_model',
+            to: 'column:producer_model.id',
+            type: 'ownership',
+          },
+        ],
+      },
+      {
+        statementIndex: 1,
+        statementType: 'SELECT',
+        sourceName: 'consumer.sql',
+        joinCount: 0,
+        complexityScore: 1,
+        nodes: [
+          {
+            id: 'producer_ref',
+            type: 'cte',
+            label: 'producer_model',
+            qualifiedName: 'analytics.producer_model',
+            metadata: { dbtModelSink: true },
+          },
+          {
+            id: 'consumer_sink',
+            type: 'output',
+            label: 'consumer_model',
+            qualifiedName: 'analytics.consumer_model',
+          },
+        ],
+        edges: [{ id: 'df', from: 'producer_ref', to: 'consumer_sink', type: 'data_flow' }],
+      },
+    ];
+
+    const { dependencies } = extractScriptDependencies(toResult(statements));
+    const producerToConsumer = dependencies.find(
+      (d) => d.sourceScript === 'producer.sql' && d.targetScript === 'consumer.sql'
+    );
+
+    expect(producerToConsumer).toBeDefined();
+    expect(producerToConsumer!.sharedTables).toEqual(['analytics.producer_model']);
+  });
 });
 
 describe('buildTableMatrix', () => {

--- a/packages/react/tests/matrixView.test.ts
+++ b/packages/react/tests/matrixView.test.ts
@@ -414,6 +414,69 @@ describe('extractScriptDependencies', () => {
     expect(producerToConsumer).toBeDefined();
     expect(producerToConsumer!.sharedTables).toEqual(['analytics.producer_model']);
   });
+
+  it('treats dbt relation sinks as written relations for script dependencies', () => {
+    const statements: TestStatement[] = [
+      {
+        statementIndex: 0,
+        statementType: 'SELECT',
+        sourceName: 'producer.sql',
+        joinCount: 0,
+        complexityScore: 1,
+        nodes: [
+          {
+            id: 'table:producer_model',
+            type: 'table',
+            label: 'producer_model',
+            qualifiedName: 'analytics.producer_model',
+          },
+          {
+            id: 'column:producer_model.id',
+            type: 'column',
+            label: 'id',
+          },
+        ],
+        edges: [
+          {
+            id: 'own:producer_model.id',
+            from: 'table:producer_model',
+            to: 'column:producer_model.id',
+            type: 'ownership',
+          },
+        ],
+      },
+      {
+        statementIndex: 1,
+        statementType: 'SELECT',
+        sourceName: 'consumer.sql',
+        joinCount: 0,
+        complexityScore: 1,
+        nodes: [
+          {
+            id: 'producer_ref',
+            type: 'table',
+            label: 'producer_model',
+            qualifiedName: 'analytics.producer_model',
+          },
+          {
+            id: 'consumer_sink',
+            type: 'output',
+            label: 'consumer_model',
+            qualifiedName: 'analytics.consumer_model',
+          },
+        ],
+        edges: [],
+      },
+    ];
+
+    const { dependencies } = extractScriptDependencies(toResult(statements));
+    const producerToConsumer = dependencies.find(
+      (d) => d.sourceScript === 'producer.sql' && d.targetScript === 'consumer.sql'
+    );
+
+    expect(producerToConsumer).toBeDefined();
+    expect(producerToConsumer!.sharedTables).toEqual(['analytics.producer_model']);
+  });
 });
 
 describe('buildTableMatrix', () => {

--- a/packages/react/tests/nodeOccurrences.test.ts
+++ b/packages/react/tests/nodeOccurrences.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { Node } from '@pondpilot/flowscope-core';
-import { getAggregationForStatement, scopeNodeToStatement } from '../src/utils/nodeOccurrences';
+import {
+  getAggregationForStatement,
+  getOccurrenceSourceName,
+  getOccurrenceSpan,
+  scopeNodeToStatement,
+} from '../src/utils/nodeOccurrences';
 
 describe('statement-scoped aggregations', () => {
   it('clears aggregation metadata for statements explicitly marked as non-aggregated', () => {
@@ -28,5 +33,33 @@ describe('statement-scoped aggregations', () => {
     expect(getAggregationForStatement(node, 0)?.function).toBe('COUNT');
     expect(getAggregationForStatement(node, 1)).toBeUndefined();
     expect(scopeNodeToStatement(node, 1).aggregation).toBeUndefined();
+  });
+
+  it('prefers relation definition occurrences before consumer refs', () => {
+    const consumerSpan = { start: 14, end: 22 };
+    const producerSpan = { start: 0, end: 14 };
+    const node: Node = {
+      id: 'table:producer',
+      type: 'table',
+      label: 'producer',
+      qualifiedName: 'producer',
+      statementIds: [0, 1],
+      metadata: {
+        occurrenceSpans: [consumerSpan, producerSpan],
+        occurrenceStatementIds: [0, 1],
+        occurrenceSourceNames: ['models/consumer.sql', 'models/producer.sql'],
+        definitionOccurrenceSpans: [producerSpan],
+        definitionOccurrenceStatementIds: [1],
+        definitionOccurrenceSourceNames: ['models/producer.sql'],
+      },
+    };
+
+    expect(getOccurrenceSpan(node, 0)).toEqual(producerSpan);
+    expect(getOccurrenceSourceName(node, 0)).toBe('models/producer.sql');
+    expect(getOccurrenceSpan(node, 1)).toEqual(consumerSpan);
+    expect(getOccurrenceSourceName(node, 1)).toBe('models/consumer.sql');
+
+    expect(scopeNodeToStatement(node, 0).nameSpans).toEqual([consumerSpan]);
+    expect(scopeNodeToStatement(node, 1).nameSpans).toEqual([producerSpan]);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #32 — dbt multi-model chains now render as connected lineage instead of disconnected per-file fragments.
- Materializes a dbt model's bare SELECT as the canonical Table node (sharing its id with consumers) instead of a per-statement Output node, so the flattener unifies producer and consumer by canonical name.
- Passes the sink id through to `analyze_query` as the target, so table-level DataFlow edges are emitted between models (matching the shape CTAS already produces).

Before: `supplies`, `stg_supplies`, `int_supplies` show up as disconnected boxes in mermaid and `fct_supplies` is missing entirely.
After: `supplies -> stg_supplies -> int_supplies -> fct_supplies` renders as one connected chain.

## Test plan
- [x] New regression test `dbt_chained_models_unify_producer_and_consumer_nodes` covering a 3-model A -> B -> C chain (asserts node unification, absence of stray Output nodes, cross-statement edges, and table-level DataFlow arrows).
- [x] Three existing dbt tests updated to assert the corrected Table sink shape instead of the old Output shape.
- [x] `cargo test --workspace` passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] CLI mermaid repro on a 3-file dbt chain shows the full `raw.supplies -> stg -> int -> fct` lineage.
- [ ] Reviewer: visual check in Vite dev server (`just build-wasm && just build-ts && just dev`) with a dbt-style 3-model repro, plus diamond and unreferenced-leaf cases.