### PR TITLE
fix(lineage): normalize Snowflake dbt column identities

### DIFF
--- a/crates/flowscope-core/src/analyzer/global.rs
+++ b/crates/flowscope-core/src/analyzer/global.rs
@@ -551,10 +551,9 @@ fn flat_edge_id(key: &EdgeIndexKey) -> Arc<str> {
 /// flat node.
 ///
 /// Precedence rules:
-/// - **First-wins** for `node_type`, `label`, and `expression`: the earliest
-///   statement to emit the node defines these and incoming values are
-///   discarded.
-/// - **None-fill** for `qualified_name`, `span`, `body_span`,
+/// - **First-wins** for `node_type` and `label`: the earliest statement to emit
+///   the node defines these and incoming values are discarded.
+/// - **None-fill** for `qualified_name`, `expression`, `span`, `body_span`,
 ///   `resolution_source`, `aggregation`, and `metadata`: existing non-`None`
 ///   values are preserved, but incoming values fill in gaps when the
 ///   existing slot is still `None`.
@@ -599,6 +598,9 @@ fn merge_node_into(
     }
     if existing.qualified_name.is_none() {
         existing.qualified_name = incoming.qualified_name;
+    }
+    if existing.expression.is_none() {
+        existing.expression = incoming.expression;
     }
     if existing.resolution_source.is_none() {
         existing.resolution_source = incoming.resolution_source;

--- a/crates/flowscope-core/src/analyzer/query.rs
+++ b/crates/flowscope-core/src/analyzer/query.rs
@@ -4,7 +4,9 @@
 //! FROM clauses, JOINs, WHERE/HAVING filters, and wildcard expansion. It builds the
 //! column-level lineage graph by tracking data flow from source columns to output columns.
 
-use super::context::{ColumnRef, OutputColumn, PendingWildcard, StatementContext};
+use super::context::{
+    ColumnRef, OutputColumn, PendingWildcard, StatementContext, DBT_MODEL_SINK_METADATA_KEY,
+};
 use super::helpers::{
     generate_column_node_id, generate_edge_id, generate_node_id, normalize_schema_type,
 };
@@ -948,13 +950,27 @@ impl<'a> Analyzer<'a> {
             .target_node
             .as_deref()
             .map(|target| generate_edge_id(target, &node_id));
+        let qualified_name = params.target_node.as_deref().and_then(|target| {
+            ctx.nodes
+                .iter()
+                .find(|node| node.id.as_ref() == target)
+                .filter(|node| {
+                    node.metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.get(DBT_MODEL_SINK_METADATA_KEY))
+                        .and_then(serde_json::Value::as_bool)
+                        == Some(true)
+                })
+                .and_then(|node| node.qualified_name.as_deref())
+                .map(|target_name| format!("{target_name}.{normalized_name}").into())
+        });
 
         // Create column node
         let col_node = Node {
             id: node_id.clone(),
             node_type: NodeType::Column,
             label: normalized_name.clone().into(),
-            qualified_name: None, // Will be set if we have target table
+            qualified_name,
             expression: params.expression.as_deref().map(Into::into),
             metadata: params.data_type.as_ref().map(|dt| {
                 let mut m = HashMap::new();
@@ -996,6 +1012,7 @@ impl<'a> Analyzer<'a> {
             if let Some(ref table_canonical) = resolved_table {
                 resolved_sources += 1;
                 let mut source_col_id = None;
+                let normalized_source_col = self.normalize_identifier(&source.column);
 
                 // Try alias-specific subquery columns first, then canonical CTE/derived columns.
                 if let Some(cte_cols) = source
@@ -1004,7 +1021,6 @@ impl<'a> Analyzer<'a> {
                     .and_then(|qualifier| ctx.resolve_subquery_columns(qualifier))
                     .or_else(|| ctx.resolve_subquery_columns(table_canonical))
                 {
-                    let normalized_source_col = self.normalize_identifier(&source.column);
                     if let Some(col) = cte_cols.iter().find(|c| c.name == normalized_source_col) {
                         source_col_id = Some(col.node_id.clone());
                     }
@@ -1037,11 +1053,13 @@ impl<'a> Analyzer<'a> {
 
                 // Fallback to generating a new ID
                 let source_col_id = source_col_id.unwrap_or_else(|| {
-                    generate_column_node_id(
-                        Some(&table_node_id),
-                        &self.normalize_identifier(&source.column),
-                    )
+                    generate_column_node_id(Some(&table_node_id), &normalized_source_col)
                 });
+                let identity_source_col = if self.tracker.is_declared(table_canonical) {
+                    normalized_source_col.as_str()
+                } else {
+                    source.column.as_str()
+                };
 
                 // Check if source column exists in schema
                 self.validate_column(ctx, table_canonical, &source.column);
@@ -1051,7 +1069,7 @@ impl<'a> Analyzer<'a> {
                     id: source_col_id.clone(),
                     node_type: NodeType::Column,
                     label: source.column.clone().into(),
-                    qualified_name: Some(format!("{}.{}", table_canonical, source.column).into()),
+                    qualified_name: Some(format!("{table_canonical}.{identity_source_col}").into()),
                     ..Default::default()
                 };
                 ctx.add_node(source_col_node);
@@ -1603,7 +1621,12 @@ impl<'a> Analyzer<'a> {
         column_name: &str,
         data_type: Option<String>,
     ) -> Option<Arc<str>> {
-        let col_node_id = generate_column_node_id(Some(source_node_id), column_name);
+        let identity_column_name = if self.tracker.is_declared(source_canonical) {
+            self.normalize_identifier(column_name)
+        } else {
+            column_name.to_string()
+        };
+        let col_node_id = generate_column_node_id(Some(source_node_id), &identity_column_name);
 
         if ctx.node_ids.contains(&col_node_id) {
             // Already exists, return the ID for edge creation
@@ -1615,7 +1638,7 @@ impl<'a> Analyzer<'a> {
             id: col_node_id.clone(),
             node_type: NodeType::Column,
             label: column_name.to_string().into(),
-            qualified_name: Some(format!("{}.{}", source_canonical, column_name).into()),
+            qualified_name: Some(format!("{source_canonical}.{identity_column_name}").into()),
             resolution_source: Some(ResolutionSource::Implied),
             ..Default::default()
         });
@@ -1639,7 +1662,7 @@ impl<'a> Analyzer<'a> {
         }
 
         // Record in source_table_columns for implied schema
-        ctx.record_source_column(source_canonical, column_name, data_type);
+        ctx.record_source_column(source_canonical, &identity_column_name, data_type);
 
         Some(col_node_id)
     }

--- a/crates/flowscope-core/tests/templating.rs
+++ b/crates/flowscope-core/tests/templating.rs
@@ -929,10 +929,18 @@ use flowscope_core::{
 /// Helper to run multi-file dbt analysis.
 #[cfg(feature = "templating")]
 fn analyze_dbt_files(files: Vec<FileSource>) -> flowscope_core::AnalyzeResult {
+    analyze_dbt_files_with_dialect(files, Dialect::Postgres)
+}
+
+#[cfg(feature = "templating")]
+fn analyze_dbt_files_with_dialect(
+    files: Vec<FileSource>,
+    dialect: Dialect,
+) -> flowscope_core::AnalyzeResult {
     let request = AnalyzeRequest {
         sql: String::new(),
         files: Some(files),
-        dialect: Dialect::Postgres,
+        dialect,
         source_name: None,
         options: None,
         schema: None,
@@ -2312,5 +2320,162 @@ fn dbt_chained_models_unify_producer_and_consumer_nodes() {
     assert!(
         has_stg_to_int,
         "should have a DataFlow edge stg_supplies -> int_supplies at the table level"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn snowflake_dbt_ref_columns_merge_with_model_definition_columns() {
+    // Regression test for https://github.com/pondpilot/flowscope/issues/45.
+    let stg_customers = r#"
+{{ config(materialized='view') }}
+WITH final AS (
+    SELECT
+        customer_id,
+        first_name,
+        last_name,
+        first_name || ' ' || last_name AS full_name,
+        created_at
+    FROM {{ source('raw', 'customers') }}
+)
+SELECT customer_id, first_name, last_name, full_name, created_at
+FROM final
+"#;
+    let customers = r#"
+SELECT customer_id, first_name, last_name, full_name, created_at
+FROM {{ ref('stg_customers') }}
+"#;
+
+    let result = analyze_dbt_files_with_dialect(
+        vec![
+            FileSource {
+                name: "models/stg_customers.sql".to_string(),
+                content: stg_customers.to_string(),
+            },
+            FileSource {
+                name: "models/customers.sql".to_string(),
+                content: customers.to_string(),
+            },
+        ],
+        Dialect::Snowflake,
+    );
+
+    assert!(
+        !result.summary.has_errors,
+        "Snowflake dbt analysis should succeed: {:?}",
+        result.issues
+    );
+
+    let stg_customers_node = result
+        .nodes
+        .iter()
+        .find(|node| {
+            node.node_type == NodeType::View
+                && node
+                    .canonical_name
+                    .as_ref()
+                    .is_some_and(|name| name.name == "STG_CUSTOMERS")
+        })
+        .expect("stg_customers model view should exist");
+    let owned_column_ids: std::collections::HashSet<_> = result
+        .edges
+        .iter()
+        .filter(|edge| edge.edge_type == EdgeType::Ownership && edge.from == stg_customers_node.id)
+        .map(|edge| edge.to.as_ref())
+        .collect();
+    let mut owned_column_labels: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|node| owned_column_ids.contains(node.id.as_ref()))
+        .map(|node| node.label.as_ref())
+        .collect();
+    owned_column_labels.sort_unstable();
+
+    assert_eq!(
+        owned_column_labels,
+        [
+            "CREATED_AT",
+            "CUSTOMER_ID",
+            "FIRST_NAME",
+            "FULL_NAME",
+            "LAST_NAME",
+        ],
+        "the model definition and downstream ref must share Snowflake-normalized column identities"
+    );
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn dbt_ref_column_merge_preserves_case_sensitive_dialect_identity() {
+    let result = analyze_dbt_files_with_dialect(
+        vec![
+            FileSource {
+                name: "models/stg_customers.sql".to_string(),
+                content: "{{ config(materialized='view') }} SELECT Customer_ID FROM raw.customers"
+                    .to_string(),
+            },
+            FileSource {
+                name: "models/customers.sql".to_string(),
+                content: "SELECT customer_id FROM {{ ref('stg_customers') }}".to_string(),
+            },
+        ],
+        Dialect::Mysql,
+    );
+
+    assert!(
+        !result.summary.has_errors,
+        "case-sensitive dbt analysis should succeed: {:?}",
+        result.issues
+    );
+
+    let stg_customers_node = result
+        .nodes
+        .iter()
+        .find(|node| node.node_type == NodeType::View && node.label.as_ref() == "stg_customers")
+        .expect("stg_customers model view should exist");
+    let owned_column_ids: std::collections::HashSet<_> = result
+        .edges
+        .iter()
+        .filter(|edge| edge.edge_type == EdgeType::Ownership && edge.from == stg_customers_node.id)
+        .map(|edge| edge.to.as_ref())
+        .collect();
+    let mut owned_column_labels: Vec<_> = result
+        .nodes
+        .iter()
+        .filter(|node| owned_column_ids.contains(node.id.as_ref()))
+        .map(|node| node.label.as_ref())
+        .collect();
+    owned_column_labels.sort_unstable();
+
+    assert_eq!(owned_column_labels, ["Customer_ID", "customer_id"]);
+}
+
+#[test]
+#[cfg(feature = "templating")]
+fn snowflake_dbt_consumer_first_column_keeps_producer_expression() {
+    let result = analyze_dbt_files_with_dialect(
+        vec![
+            FileSource {
+                name: "models/customers.sql".to_string(),
+                content: "SELECT full_name FROM {{ ref('stg_customers') }}".to_string(),
+            },
+            FileSource {
+                name: "models/stg_customers.sql".to_string(),
+                content: "{{ config(materialized='view') }} SELECT first_name || last_name AS full_name FROM raw.customers"
+                    .to_string(),
+            },
+        ],
+        Dialect::Snowflake,
+    );
+
+    let full_name = result
+        .nodes
+        .iter()
+        .find(|node| node.qualified_name.as_deref() == Some("STG_CUSTOMERS.FULL_NAME"))
+        .expect("consumer and producer full_name columns should merge");
+
+    assert_eq!(
+        full_name.expression.as_deref(),
+        Some("first_name || last_name")
     );
 }


### PR DESCRIPTION
## Summary

- assign dbt model output columns owner-qualified identities
- normalize inferred `ref()` column identities with the configured dialect
- preserve distinct identities for case-sensitive dialects
- retain producer expression metadata when a consumer is analyzed first

## Root cause

Snowflake dbt model definition columns used normalized uppercase identities, while downstream `ref()` source columns kept lowercase qualified identities. Global graph flattening therefore treated them as distinct columns even though both were owned by the same model relation.

## Validation

- `cargo fmt --all -- --check`
- focused Snowflake dbt regression tests
- case-sensitive dialect identity regression
- consumer-first merge regression
- related global self-join/CTE and Oracle view rename tests
- `just test-core`

Fixes #45