### PR TITLE
fix(app): hash file contents for worker synchronization

### DIFF
--- a/app/src/lib/__tests__/analysis-hash.test.ts
+++ b/app/src/lib/__tests__/analysis-hash.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFileSyncKey } from '../analysis-hash';
+
+describe('buildFileSyncKey', () => {
+  it('changes when same-length file content changes', () => {
+    const before = buildFileSyncKey({
+      files: [{ name: 'query.sql', content: 'SELECT 1' }],
+    });
+    const after = buildFileSyncKey({
+      files: [{ name: 'query.sql', content: 'SELECT 2' }],
+    });
+
+    expect(after).not.toBe(before);
+  });
+
+  it('is stable for unchanged files', () => {
+    const files = [
+      { name: 'models/orders.sql', content: 'SELECT * FROM raw_orders' },
+      { name: 'models/customers.sql', content: 'SELECT * FROM raw_customers' },
+    ];
+
+    const first = buildFileSyncKey({ files });
+    const second = buildFileSyncKey({
+      files: files.map((file) => ({ ...file })),
+    });
+
+    expect(second).toBe(first);
+  });
+});

--- a/app/src/lib/__tests__/analysis-hash.test.ts
+++ b/app/src/lib/__tests__/analysis-hash.test.ts
@@ -10,8 +10,12 @@ describe('buildFileSyncKey', () => {
     const after = buildFileSyncKey({
       files: [{ name: 'query.sql', content: 'SELECT 2' }],
     });
+    const restored = buildFileSyncKey({
+      files: [{ name: 'query.sql', content: 'SELECT 1' }],
+    });
 
     expect(after).not.toBe(before);
+    expect(restored).toBe(before);
   });
 
   it('is stable for unchanged files', () => {

--- a/app/src/lib/__tests__/analysis-worker.test.ts
+++ b/app/src/lib/__tests__/analysis-worker.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { syncAnalysisFiles, terminateAnalysisWorker } from '../analysis-worker';
+import type { AnalysisWorkerRequest, AnalysisWorkerResponse } from '../../workers/analysis.worker';
+
+class TestWorker {
+  static instances: TestWorker[] = [];
+
+  onmessage: ((event: MessageEvent<AnalysisWorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  readonly messages: AnalysisWorkerRequest[] = [];
+  readonly terminate = vi.fn();
+
+  constructor() {
+    TestWorker.instances.push(this);
+  }
+
+  postMessage(message: AnalysisWorkerRequest): void {
+    this.messages.push(message);
+    this.onmessage?.({
+      data: {
+        type: 'sync-result',
+        requestId: message.requestId,
+      },
+    } as MessageEvent<AnalysisWorkerResponse>);
+  }
+}
+
+describe('syncAnalysisFiles', () => {
+  beforeEach(() => {
+    TestWorker.instances = [];
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.stubGlobal('Worker', TestWorker);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    terminateAnalysisWorker();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('resyncs same-length edits and skips unchanged files', async () => {
+    const originalFiles = [{ name: 'query.sql', content: 'SELECT 1' }];
+
+    await syncAnalysisFiles(originalFiles);
+    await syncAnalysisFiles(originalFiles.map((file) => ({ ...file })));
+    await syncAnalysisFiles([{ name: 'query.sql', content: 'SELECT 2' }]);
+
+    expect(TestWorker.instances).toHaveLength(1);
+    const syncMessages = TestWorker.instances[0].messages.filter(
+      (message) => message.type === 'sync-files'
+    );
+    expect(syncMessages).toHaveLength(2);
+    expect(syncMessages[1].syncPayload?.files).toEqual([
+      { name: 'query.sql', content: 'SELECT 2' },
+    ]);
+  });
+});

--- a/app/src/lib/analysis-hash.ts
+++ b/app/src/lib/analysis-hash.ts
@@ -12,6 +12,10 @@ const HASH_VERSION = 'v5';
 const FNV_OFFSET_BASIS = 0xcbf29ce484222325n;
 const FNV_PRIME = 0x100000001b3n;
 const FNV_MASK = 0xffffffffffffffffn;
+const FNV_OFFSET_HIGH = 0xcbf29ce4;
+const FNV_OFFSET_LOW = 0x84222325;
+const FNV_PRIME_LOW = 0x1b3;
+const UINT32_SIZE = 0x100000000;
 
 export interface AnalysisHashInput {
   files: Array<{ name: string; content: string }>;
@@ -26,6 +30,19 @@ export interface AnalysisHashInput {
 export interface FileSyncInput {
   files: Array<{ name: string; content: string }>;
 }
+
+interface FastHashState {
+  high: number;
+  low: number;
+}
+
+interface CachedFileSyncDigest {
+  name: string;
+  content: string;
+  digest: string;
+}
+
+let previousFileSyncDigests: CachedFileSyncDigest[] = [];
 
 /**
  * Update hash with a string value using FNV-1a algorithm.
@@ -56,6 +73,46 @@ function updateHashWithField(currentHash: bigint, value: string): bigint {
   return hash;
 }
 
+/**
+ * Update a 64-bit FNV-1a hash using two 32-bit words.
+ *
+ * This produces the same hash as the BigInt implementation without performing
+ * BigInt arithmetic for every character on the browser's main thread.
+ */
+function updateFastHashWithString(currentHash: FastHashState, value: string): FastHashState {
+  let { high, low } = currentHash;
+
+  for (let index = 0; index < value.length; index += 1) {
+    low = (low ^ value.charCodeAt(index)) >>> 0;
+
+    // The 64-bit FNV prime is 2^40 + 0x1b3. Multiplication by 0x1b3
+    // stays within JavaScript's exact integer range, so carry can be
+    // applied to the high word without BigInt.
+    const lowProduct = low * FNV_PRIME_LOW;
+    const carry = Math.floor(lowProduct / UINT32_SIZE);
+    high = (Math.imul(high, FNV_PRIME_LOW) + carry + (low << 8)) >>> 0;
+    low = lowProduct >>> 0;
+  }
+
+  return { high, low };
+}
+
+function updateFastHashWithField(currentHash: FastHashState, value: string): FastHashState {
+  const hash = updateFastHashWithString(currentHash, `${value.length}:`);
+  return updateFastHashWithString(hash, value);
+}
+
+function formatFastHash(hash: FastHashState): string {
+  return `${hash.high.toString(16).padStart(8, '0')}${hash.low.toString(16).padStart(8, '0')}`;
+}
+
+function buildFileDigest(file: FileSyncInput['files'][number]): string {
+  let hash = { high: FNV_OFFSET_HIGH, low: FNV_OFFSET_LOW };
+  hash = updateFastHashWithField(hash, file.name);
+  hash = updateFastHashWithField(hash, file.content);
+  return formatFastHash(hash);
+}
+
 export function buildAnalysisCacheKey(input: AnalysisHashInput): string {
   let hash = FNV_OFFSET_BASIS;
   // Fixed-format fields use updateHashWithString (no collision risk)
@@ -77,16 +134,22 @@ export function buildAnalysisCacheKey(input: AnalysisHashInput): string {
 }
 
 export function buildFileSyncKey(input: FileSyncInput): string {
-  let hash = FNV_OFFSET_BASIS;
-  // Fixed-format fields
-  hash = updateHashWithString(hash, `${HASH_VERSION}-files`);
-  hash = updateHashWithString(hash, String(input.files.length));
+  let hash = { high: FNV_OFFSET_HIGH, low: FNV_OFFSET_LOW };
+  hash = updateFastHashWithString(hash, `${HASH_VERSION}-files`);
+  hash = updateFastHashWithString(hash, String(input.files.length));
 
-  for (const file of input.files) {
-    // Variable-length fields use length-prefixed hashing
-    hash = updateHashWithField(hash, file.name);
-    hash = updateHashWithField(hash, file.content);
+  const nextFileSyncDigests: CachedFileSyncDigest[] = [];
+  for (const [index, file] of input.files.entries()) {
+    const cached = previousFileSyncDigests[index];
+    const digest =
+      cached && cached.name === file.name && cached.content === file.content
+        ? cached.digest
+        : buildFileDigest(file);
+
+    nextFileSyncDigests.push({ ...file, digest });
+    hash = updateFastHashWithField(hash, digest);
   }
+  previousFileSyncDigests = nextFileSyncDigests;
 
-  return hash.toString(16).padStart(16, '0');
+  return formatFastHash(hash);
 }

--- a/app/src/lib/analysis-hash.ts
+++ b/app/src/lib/analysis-hash.ts
@@ -85,7 +85,7 @@ export function buildFileSyncKey(input: FileSyncInput): string {
   for (const file of input.files) {
     // Variable-length fields use length-prefixed hashing
     hash = updateHashWithField(hash, file.name);
-    hash = updateHashWithString(hash, String(file.content.length));
+    hash = updateHashWithField(hash, file.content);
   }
 
   return hash.toString(16).padStart(16, '0');


### PR DESCRIPTION
## Summary

- hash each file's full content in the worker synchronization key
- keep unchanged file sets stable so redundant worker transfers are still skipped
- cover same-length edits at the hash and worker synchronization boundaries

## Root cause

`buildFileSyncKey` hashed file names and content lengths, but not content. Equal-length edits kept the same key, so `syncAnalysisFiles` could skip a required worker update and analyze stale SQL.

## Impact

Same-length SQL edits now trigger worker synchronization while unchanged files retain the existing fast path.

## Validation

- `yarn --cwd app test src/lib/__tests__/analysis-hash.test.ts src/lib/__tests__/analysis-worker.test.ts`
- `yarn --cwd app typecheck`
- `yarn --cwd app lint`