### PR TITLE
docs: reconcile privacy and version claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,5 +186,5 @@ Use a single repo tag for each release (`vX.Y.Z`) and align Rust workspace + npm
 
 ## Notes
 
-- The demo app (`app/`) and VS Code webview (`vscode/webview-ui/`) currently define no tests.
+- The demo app (`app/`) has a Vitest suite. The VS Code webview (`vscode/webview-ui/`) currently defines no tests.
 - For full CI parity, `just check` runs formatting checks, lint, typecheck, and schema checks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlowScope
 
-[![CI](https://github.com/pondpilot/flowscope/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/pondpilot/flowscope/actions/workflows/ci.yml)
+[![CI](https://github.com/pondpilot/flowscope/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/pondpilot/flowscope/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-available-brightgreen.svg)](docs/README.md)
 [![codecov](https://codecov.io/gh/pondpilot/flowscope/graph/badge.svg)](https://codecov.io/gh/pondpilot/flowscope)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
@@ -14,7 +14,7 @@
 
 FlowScope includes a full web application at [flowscope.pondpilot.io](https://flowscope.pondpilot.io) for interactive, multi-file SQL lineage analysis.
 
-Under the hood, it is a privacy-first SQL lineage engine that runs entirely in the browser. Built with Rust and WebAssembly, it analyzes SQL queries to produce lineage graphs that describe how tables, CTEs, and columns flow through transformations.
+Under the hood, it is a client-side SQL lineage engine that runs entirely in the browser. Built with Rust and WebAssembly, it analyzes SQL queries to produce lineage graphs that describe how tables, CTEs, and columns flow through transformations.
 
 The engine is designed for embedding into web apps, browser extensions, and developer tools that need instant lineage analysis without sending SQL to a server.
 
@@ -33,7 +33,9 @@ Features:
 - dbt/Jinja template preprocessing for dbt models
 - Export to Mermaid, JSON, CSV, Excel, or HTML reports
 - Librarian — AI chat panel that answers questions about your data based on lineage analysis and uploaded PDF docs
-- All processing happens in your browser — your SQL never leaves your machine
+- SQL lineage analysis runs in your browser by default. Librarian sends prompt context to an AI provider only after you configure the provider and submit a question.
+
+When Librarian is used, its request includes the active SQL snippet, formatted lineage, relevant text excerpts and citations from uploaded PDFs, recent Librarian chat history, and the question. The browser sends this data directly to the configured AI provider. PDF extraction, embeddings, and vector search remain local. See the [Librarian privacy details](docs/librarian.md#privacy).
 
 ### Command-Line Interface
 
@@ -106,7 +108,7 @@ See [CLI documentation](crates/flowscope-cli/README.md) for all options.
 
 ## Key Features
 
-- Client-side analysis with zero data egress
+- Local SQL lineage analysis by default, with explicit provider requests only when Librarian is configured and used
 - Multi-dialect coverage (PostgreSQL, Snowflake, BigQuery, DuckDB, Redshift, and more)
 - dbt and Jinja templating support with built-in macro stubs (`ref()`, `source()`, `var()`)
 - Table and column lineage with schema-aware wildcard expansion

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ We release patches for security vulnerabilities for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.8.x   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/app/README.md
+++ b/app/README.md
@@ -5,10 +5,11 @@ The official web interface for FlowScope. This application demonstrates the full
 ## Features
 
 - **Interactive Lineage Graph:** Visualize table and column dependencies.
-- **Multi-File Workspace:** Manage multiple SQL files and analyze cross-file dependencies (simulated).
+- **Multi-File Workspace:** Manage multiple SQL files and analyze cross-file dependencies.
 - **Schema Editor:** Define table schemas to enable advanced analysis features like wildcard expansion and column validation.
 - **SQL Linting:** Real-time lint diagnostics in the Issues panel. 72 rules check aliasing, layout, conventions, and structure.
-- **Privacy-First:** All processing happens locally in the browser via WebAssembly.
+- **Local Analysis:** SQL lineage analysis runs locally in the browser via WebAssembly.
+- **Opt-in Librarian:** After you configure an AI provider and submit a question, Librarian sends the active SQL snippet, formatted lineage, relevant PDF text excerpts and citations, recent chat history, and the question to that provider.
 
 ## Development
 

--- a/app/src/components/WelcomeModal.tsx
+++ b/app/src/components/WelcomeModal.tsx
@@ -38,7 +38,7 @@ export function WelcomeModal({ onClose }: WelcomeModalProps) {
         <DialogHeader>
           <DialogTitle className="text-xl">Welcome to FlowScope</DialogTitle>
           <DialogDescription>
-            A privacy-first SQL lineage engine that runs entirely in your browser.
+            A client-side SQL lineage engine that runs entirely in your browser.
           </DialogDescription>
         </DialogHeader>
 
@@ -66,9 +66,10 @@ export function WelcomeModal({ onClose }: WelcomeModalProps) {
           <div className="flex items-start gap-3">
             <Shield className="h-5 w-5 text-muted-foreground mt-0.5 shrink-0" />
             <div>
-              <p className="font-medium text-sm">Privacy First</p>
+              <p className="font-medium text-sm">Local by Default</p>
               <p className="text-sm text-muted-foreground">
-                All analysis runs locally in your browser. Your SQL never leaves your machine.
+                SQL lineage analysis runs in your browser. Librarian sends prompt context only after
+                you configure a provider and ask a question.
               </p>
             </div>
           </div>

--- a/app/src/workers/analysis.worker.ts
+++ b/app/src/workers/analysis.worker.ts
@@ -264,11 +264,7 @@ async function runAnalysis(
     resolvedPayload.templateMode && resolvedPayload.templateMode !== 'raw'
       ? { mode: resolvedPayload.templateMode, context: {} }
       : undefined;
-  // Note: templateConfig is supported by the WASM API but not yet typed in @pondpilot/flowscope-core.
-  // The request is serialized to JSON, and the Rust side deserializes it with templateConfig support.
-  const analysisRequest: Parameters<typeof analyzeSql>[0] & {
-    templateConfig?: { mode: TemplateMode; context: Record<string, unknown> };
-  } = {
+  const analysisRequest: Parameters<typeof analyzeSql>[0] = {
     sql: '',
     files: resolvedPayload.files,
     dialect: resolvedPayload.dialect,

--- a/crates/flowscope-export/README.md
+++ b/crates/flowscope-export/README.md
@@ -22,8 +22,8 @@ Add it to your project alongside `flowscope-core`:
 
 ```toml
 [dependencies]
-flowscope-core = "0.1.0"
-flowscope-export = "0.1.0"
+flowscope-core = "0.8.0"
+flowscope-export = "0.8.0"
 ```
 
 ## License

--- a/docs/librarian.md
+++ b/docs/librarian.md
@@ -1,6 +1,6 @@
 # Librarian — User Guide
 
-Librarian is an AI-powered chat panel inside FlowScope that answers questions about your SQL based on data lineage analysis and uploaded PDF documentation. It runs entirely in the browser — no backend.
+Librarian is an AI-powered chat panel inside FlowScope that answers questions about your SQL based on data lineage analysis and uploaded PDF documentation. The panel prepares its context in the browser and sends each question directly to the AI provider you configure; FlowScope does not proxy the request through its own backend.
 
 ## Opening the Panel
 
@@ -124,8 +124,11 @@ Check that the API key is valid and has quota. For Anthropic, ensure the model n
 
 ## Privacy
 
-- All processing (PDF extraction, embeddings, vector search) runs locally in your browser
-- Your SQL, PDFs, and questions are sent **only** to the AI provider you configured
+- SQL lineage analysis, PDF extraction, embeddings, and vector search run locally in your browser
+- No Librarian prompt data is sent until you configure an AI provider and submit a question
+- Each Librarian request sends the active SQL snippet (up to 3,000 characters), formatted lineage, up to five relevant PDF text excerpts with file and page citations, up to 10 recent chat messages, the configured system prompt, and your question to that provider
+- Uploaded PDF files are not sent to the provider; only the relevant text excerpts selected locally are included
+- The provider's data handling and retention policies apply to the request
 - No telemetry, no analytics, no third-party tracking
 
 ## What Librarian Does NOT Do

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -41,8 +41,8 @@ Confirm the tarball includes:
 Publishing is triggered by tag pushes in CI:
 
 ```bash
-git tag v0.8.0
-git push origin v0.8.0
+git tag vX.Y.Z
+git push origin vX.Y.Z
 ```
 
 The workflow builds WASM + TypeScript and runs `npm publish --workspaces=false` from `packages/core`.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -41,8 +41,8 @@ Confirm the tarball includes:
 Publishing is triggered by tag pushes in CI:
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag v0.8.0
+git push origin v0.8.0
 ```
 
 The workflow builds WASM + TypeScript and runs `npm publish --workspaces=false` from `packages/core`.

--- a/docs/workspace-structure.md
+++ b/docs/workspace-structure.md
@@ -64,5 +64,5 @@ app/ and vscode/webview-ui
 
 ## Notes
 
-- The demo app and VS Code webview currently define no tests.
+- The demo app has a Vitest suite. The VS Code webview currently defines no tests.
 - API schema snapshots live in `docs/api_schema.json` and are validated by `just check-schema`.


### PR DESCRIPTION
## Summary

- align the CI badge and supported-version documentation with `master` and the 0.8 workspace
- distinguish local SQL/PDF processing from the provider-bound Librarian payload
- update stale app test, multi-file lineage, publishing, dependency, and `templateConfig` references

## Why

The documentation retained 0.1-era and pre-Librarian statements after the release line and web app behavior changed. This produced incorrect version guidance and privacy claims broader than the implementation.

## Impact

Users now get a precise privacy boundary: lineage analysis is local by default, while Librarian sends the active SQL snippet, formatted lineage, relevant PDF excerpts and citations, recent chat history, the system prompt, and the question only after a provider is configured and a question is submitted. There is no product behavior change.

## Validation

- checked local links and anchors in all eight changed Markdown files
- searched affected documentation and source copy for the stale claims
- verified `SECURITY.md` matches workspace version 0.8.x
- verified the `master` CI badge returns HTTP 200
- `prettier --check app/src/components/WelcomeModal.tsx app/src/workers/analysis.worker.ts`
- `yarn workspace @pondpilot/flowscope-app typecheck`
- `yarn --cwd app test` (328 tests)
- `git diff --check`
