### PR TITLE
refactor(react): split GraphView responsibilities

### DIFF
--- a/packages/react/src/components/GraphView.tsx
+++ b/packages/react/src/components/GraphView.tsx
@@ -1,32 +1,18 @@
 import { useMemo, useCallback, useEffect, useRef, useState, type JSX } from 'react';
-import {
-  ReactFlow,
-  Background,
-  Controls,
-  MiniMap,
-  useNodesState,
-  useEdgesState,
-  useReactFlow,
-  Panel,
-} from '@xyflow/react';
-import type { Node as FlowNode, Edge as FlowEdge, Viewport } from '@xyflow/react';
+import { ReactFlow, useNodesState, useEdgesState } from '@xyflow/react';
+import type { Node as FlowNode, Edge as FlowEdge } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { LayoutList, Maximize2, Minimize2, Route, GitBranch } from 'lucide-react';
 import type { AnalyzeResult, Node as LineageNode } from '@pondpilot/flowscope-core';
 
 import { useLineage, useLineageStore } from '../store';
-import { useNodeFocus } from '../hooks/useNodeFocus';
 import { useGraphFiltering } from '../hooks/useGraphFiltering';
 import { useOccurrenceShortcuts } from '../hooks/useOccurrenceShortcuts';
 import type { GraphViewProps, TableNodeData, LayoutAlgorithm } from '../types';
 import {
   getLayoutedElements,
   getLayoutedElementsInWorker,
-  getFastLayoutedNodes,
   cancelLayoutRequests,
 } from '../utils/layout';
-import { LayoutSelector } from './LayoutSelector';
-import { isTableNodeData } from '../utils/graphTraversal';
 import { GRAPH_DEBUG, nowMs } from '../utils/debug';
 import {
   buildTableGraphInWorker,
@@ -43,200 +29,27 @@ import { ColumnNode } from './ColumnNode';
 import { SimpleTableNode } from './SimpleTableNode';
 import { TableNode } from './TableNode';
 import { AnimatedEdge } from './AnimatedEdge';
-import { ViewModeSelector } from './ViewModeSelector';
-import { GraphSearchControl } from './GraphSearchControl';
-import { TableFilterDropdown } from './TableFilterDropdown';
-import { Legend } from './Legend';
-import { LayoutProgressIndicator } from './LayoutProgressIndicator';
-import type { SearchableType } from '../hooks/useSearchSuggestions';
 import {
-  GraphTooltip,
-  GraphTooltipContent,
-  GraphTooltipProvider,
-  GraphTooltipTrigger,
-  GraphTooltipArrow,
-  GraphTooltipPortal,
-} from './ui/graph-tooltip';
+  FitViewHandler,
+  NodeFocusHandler,
+  RevealHandler,
+  ViewportHandler,
+} from './GraphViewHandlers';
+import { GraphViewControls } from './GraphViewControls';
+import { REVEAL_PULSE_DURATION_MS } from '../constants';
 import {
-  GRAPH_CONFIG,
-  NODE_FOCUS_DELAY_MS,
-  PANEL_STYLES,
-  REVEAL_PULSE_DURATION_MS,
-  getMinimapNodeColor,
-} from '../constants';
+  applyRenderDataToEdges,
+  applyRenderDataToNodes,
+  createRenderGraphIndex,
+  enhanceGraphWithHighlights,
+  getGraphSearchableTypes,
+  getNodeCollapseStates,
+  hasNodeCollapseChanged,
+  prepareProgressiveLayoutNodes,
+  shouldShowMiniMap,
+} from '../utils/graphViewModel';
 
-const MINIMAP_NODE_LIMIT = 2000;
 const ELK_NODE_LIMIT = 2000;
-
-/**
- * Threshold for determining when to treat a graph as "new" vs "evolved".
- * If fewer than this fraction of nodes have existing positions, we use
- * fast layout for all nodes instead of preserving positions.
- * 0.5 means: if less than half the nodes match, treat as new graph.
- */
-const NODE_OVERLAP_THRESHOLD = 0.5;
-
-/**
- * Helper component to handle node focusing.
- * Must be rendered inside ReactFlow to access useReactFlow hook.
- */
-function NodeFocusHandler({
-  focusNodeId,
-  onFocusApplied,
-}: {
-  focusNodeId?: string;
-  onFocusApplied?: () => void;
-}): null {
-  useNodeFocus({ focusNodeId, onFocusApplied });
-  return null;
-}
-
-/**
- * Watches the store's `revealRequest` and drives both the graph's fitView
- * animation and the transient pulse class on the target node. A nonce is used
- * instead of a plain node id so re-revealing the same node restarts the
- * animation.
- */
-function RevealHandler({ applyPulse }: { applyPulse: (nodeId: string) => void }): null {
-  const revealRequest = useLineageStore((store) => store.revealRequest);
-  const clearRevealRequest = useLineageStore((store) => store.clearRevealRequest);
-  const { fitView, getNode } = useReactFlow();
-  const lastNonceRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!revealRequest) {
-      lastNonceRef.current = null;
-      return;
-    }
-    if (revealRequest.nonce === lastNonceRef.current) return;
-    lastNonceRef.current = revealRequest.nonce;
-
-    // ReactFlow needs a tick to render newly-selected nodes before we can
-    // query their positions (same reason `useNodeFocus` uses NODE_FOCUS_DELAY_MS).
-    const timer = setTimeout(() => {
-      const node = getNode(revealRequest.nodeId);
-      if (node) {
-        fitView({ nodes: [{ id: revealRequest.nodeId }], duration: 500, padding: 0.5 });
-        applyPulse(revealRequest.nodeId);
-      }
-      clearRevealRequest();
-    }, NODE_FOCUS_DELAY_MS);
-
-    return () => clearTimeout(timer);
-  }, [revealRequest, fitView, getNode, applyPulse, clearRevealRequest]);
-
-  return null;
-}
-
-/**
- * Helper component to trigger fitView when fitViewTrigger changes.
- * Must be rendered inside ReactFlow to access useReactFlow hook.
- */
-function FitViewHandler({ trigger }: { trigger?: number }): null {
-  const { fitView } = useReactFlow();
-  const lastTriggerRef = useRef(trigger);
-
-  useEffect(() => {
-    if (trigger !== undefined && trigger !== lastTriggerRef.current) {
-      lastTriggerRef.current = trigger;
-      // Small delay to ensure nodes are rendered
-      setTimeout(() => {
-        fitView({ padding: 0.2, duration: 200 });
-      }, 50);
-    }
-  }, [trigger, fitView]);
-
-  return null;
-}
-
-/**
- * Helper component to handle viewport changes and restoration.
- * Must be rendered inside ReactFlow to access useReactFlow hook.
- */
-function ViewportHandler({
-  initialViewport,
-  onViewportChange,
-}: {
-  initialViewport?: Viewport;
-  onViewportChange?: (viewport: Viewport) => void;
-}): null {
-  const { setViewport, getViewport } = useReactFlow();
-  const hasRestoredRef = useRef(false);
-  const previousInitialViewportRef = useRef<Viewport | undefined>(initialViewport);
-  const viewportChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Cleanup timer on unmount
-  useEffect(() => {
-    return () => {
-      if (viewportChangeTimerRef.current) {
-        clearTimeout(viewportChangeTimerRef.current);
-      }
-    };
-  }, []);
-
-  // Reset restoration flag when initial viewport changes (e.g., project switch)
-  useEffect(() => {
-    if (previousInitialViewportRef.current !== initialViewport) {
-      hasRestoredRef.current = false;
-      previousInitialViewportRef.current = initialViewport;
-    }
-  }, [initialViewport]);
-
-  // Restore initial viewport as needed
-  useEffect(() => {
-    if (initialViewport && !hasRestoredRef.current) {
-      // Delay to ensure ReactFlow is ready
-      const timer = setTimeout(() => {
-        setViewport(initialViewport, { duration: 0 });
-        hasRestoredRef.current = true;
-      }, 100);
-      return () => clearTimeout(timer);
-    }
-  }, [initialViewport, setViewport]);
-
-  // Debounced viewport change callback
-  useEffect(() => {
-    if (!onViewportChange) return;
-
-    const handleViewportChange = () => {
-      if (viewportChangeTimerRef.current) {
-        clearTimeout(viewportChangeTimerRef.current);
-      }
-      viewportChangeTimerRef.current = setTimeout(() => {
-        const viewport = getViewport();
-        onViewportChange(viewport);
-      }, 300);
-    };
-
-    // Use MutationObserver on the viewport's style attribute rather than ReactFlow's
-    // onMove/onViewportChange events. Those events fire at very high frequency during
-    // pan/zoom operations which would cause excessive state updates and re-renders.
-    // The MutationObserver approach with debouncing provides more reliable, batched updates.
-    const container = document.querySelector('.react-flow__viewport');
-    if (container) {
-      const observer = new MutationObserver(handleViewportChange);
-      observer.observe(container, { attributes: true, attributeFilter: ['style'] });
-      return () => {
-        observer.disconnect();
-        if (viewportChangeTimerRef.current) {
-          clearTimeout(viewportChangeTimerRef.current);
-        }
-      };
-    }
-  }, [onViewportChange, getViewport]);
-
-  return null;
-}
-
-// Type guard for data with isSelected property
-interface SelectableNodeData {
-  isSelected?: boolean;
-  [key: string]: unknown;
-}
-
-function isSelectableNodeData(data: unknown): data is SelectableNodeData {
-  return typeof data === 'object' && data !== null;
-}
 
 const nodeTypes = {
   tableNode: TableNode,
@@ -248,104 +61,6 @@ const nodeTypes = {
 const edgeTypes = {
   animated: AnimatedEdge,
 };
-
-interface ToolbarToggleButtonProps {
-  isActive: boolean;
-  onClick: () => void;
-  ariaLabel: string;
-  tooltip: string;
-  icon: React.ReactNode;
-}
-
-/**
- * Reusable toggle button for graph toolbar actions.
- * Provides consistent styling and tooltip behavior.
- */
-function ToolbarToggleButton({
-  isActive,
-  onClick,
-  ariaLabel,
-  tooltip,
-  icon,
-}: ToolbarToggleButtonProps): JSX.Element {
-  return (
-    <div className={PANEL_STYLES.container} data-graph-panel>
-      <GraphTooltipProvider>
-        <GraphTooltip delayDuration={300}>
-          <GraphTooltipTrigger asChild>
-            <button
-              onClick={onClick}
-              className={`
-                inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full transition-all duration-200
-                ${isActive ? 'bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100' : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}
-                focus-visible:outline-hidden
-              `}
-              aria-label={ariaLabel}
-              aria-pressed={isActive}
-            >
-              {icon}
-            </button>
-          </GraphTooltipTrigger>
-          <GraphTooltipPortal>
-            <GraphTooltipContent side="bottom">
-              <p>{tooltip}</p>
-              <GraphTooltipArrow />
-            </GraphTooltipContent>
-          </GraphTooltipPortal>
-        </GraphTooltip>
-      </GraphTooltipProvider>
-    </div>
-  );
-}
-
-function enhanceGraphWithHighlights(
-  graph: { nodes: FlowNode[]; edges: FlowEdge[] },
-  highlightIds: Set<string>
-): { nodes: FlowNode[]; edges: FlowEdge[] } {
-  const enhancedNodes = graph.nodes.map((node) => {
-    const isHighlighted = highlightIds.has(node.id);
-
-    // Handle Table Nodes with columns
-    if (isTableNodeData(node.data)) {
-      const nodeData = node.data;
-      const enhancedColumns = nodeData.columns.map((col) => ({
-        ...col,
-        isHighlighted: highlightIds.has(col.id),
-      }));
-
-      return {
-        ...node,
-        data: {
-          ...nodeData,
-          columns: enhancedColumns,
-          isSelected: nodeData.isSelected || isHighlighted,
-        },
-      };
-    }
-
-    // Handle Script Nodes and generic nodes
-    const currentIsSelected = isSelectableNodeData(node.data) ? node.data.isSelected : false;
-    return {
-      ...node,
-      data: {
-        ...node.data,
-        isSelected: currentIsSelected || isHighlighted,
-      },
-    };
-  });
-
-  const enhancedEdges = graph.edges.map((edge) => ({
-    ...edge,
-    animated: highlightIds.has(edge.id),
-    zIndex: highlightIds.has(edge.id) ? GRAPH_CONFIG.HIGHLIGHTED_EDGE_Z_INDEX : 0,
-    data: {
-      ...edge.data,
-      isHighlighted: highlightIds.has(edge.id),
-    },
-  }));
-
-  return { nodes: enhancedNodes, edges: enhancedEdges };
-}
 
 export function GraphView({
   className,
@@ -424,15 +139,10 @@ export function GraphView({
   }, []);
 
   // Determine searchable types based on view mode and column edges setting
-  const searchableTypes = useMemo((): SearchableType[] => {
-    if (viewMode === 'script') {
-      return ['script', 'table', 'view', 'cte'];
-    }
-    // Table view: include columns when showing column edges
-    return showColumnEdges
-      ? ['table', 'view', 'cte', 'column', 'script']
-      : ['table', 'view', 'cte', 'script'];
-  }, [viewMode, showColumnEdges]);
+  const searchableTypes = useMemo(
+    () => getGraphSearchableTypes(viewMode, showColumnEdges),
+    [viewMode, showColumnEdges]
+  );
 
   // State for async graph building results
   const [builtGraph, setBuiltGraph] = useState<{ nodes: FlowNode[]; edges: FlowEdge[] }>({
@@ -595,24 +305,8 @@ export function GraphView({
   const layoutNodes = filteredGraph.nodes;
   const layoutEdges = filteredGraph.edges;
 
-  const renderNodeDataById = useMemo(() => {
-    const map = new Map<string, FlowNode['data']>();
-    for (const node of renderGraph.nodes) {
-      map.set(node.id, node.data);
-    }
-    return map;
-  }, [renderGraph.nodes]);
-
-  const renderEdgeById = useMemo(() => {
-    const map = new Map<string, FlowEdge>();
-    for (const edge of renderGraph.edges) {
-      map.set(edge.id, edge);
-    }
-    return map;
-  }, [renderGraph.edges]);
-
-  const showMiniMap =
-    renderGraph.nodes.length > 0 && renderGraph.nodes.length <= MINIMAP_NODE_LIMIT;
+  const renderGraphIndex = useMemo(() => createRenderGraphIndex(renderGraph), [renderGraph]);
+  const showMiniMap = shouldShowMiniMap(renderGraph.nodes.length);
 
   useEffect(() => {
     if (!analysisResult) {
@@ -688,54 +382,9 @@ export function GraphView({
     if (GRAPH_DEBUG) console.time('[Layout] Stage 1: preserve positions');
     // Stage 1: Preserve existing node positions for smoother transitions.
     // This prevents nodes from jumping to origin (0,0) while layout computes.
-    setNodes((currentNodes) => {
-      if (currentNodes.length === 0) {
-        if (GRAPH_DEBUG) console.time('[Layout] getFastLayoutedNodes');
-        const fastResult = getFastLayoutedNodes(renderGraphSnapshot.nodes, direction);
-        if (GRAPH_DEBUG) console.timeEnd('[Layout] getFastLayoutedNodes');
-        return fastResult;
-      }
-
-      const positionMap = new Map(currentNodes.map((node) => [node.id, node.position]));
-
-      // Count how many new nodes don't have existing positions
-      const nodesWithoutPosition = renderGraphSnapshot.nodes.filter(
-        (node) => !positionMap.has(node.id)
-      );
-      const matchCount = renderGraphSnapshot.nodes.length - nodesWithoutPosition.length;
-
-      // If less than threshold of nodes have existing positions, treat as new graph.
-      // This handles project switch where node IDs completely change.
-      if (matchCount < renderGraphSnapshot.nodes.length * NODE_OVERLAP_THRESHOLD) {
-        if (GRAPH_DEBUG) console.log('[Layout] Low node overlap, using fast layout');
-        return getFastLayoutedNodes(renderGraphSnapshot.nodes, direction);
-      }
-
-      // If all nodes have existing positions, just preserve them (no fast layout needed)
-      if (nodesWithoutPosition.length === 0) {
-        if (GRAPH_DEBUG) console.log('[Layout] All nodes have positions, preserving');
-        return renderGraphSnapshot.nodes.map((node) => ({
-          ...node,
-          position: positionMap.get(node.id)!,
-        }));
-      }
-
-      // Only compute fast layout when there are actually new nodes that need positions
-      if (GRAPH_DEBUG)
-        console.log(`[Layout] ${nodesWithoutPosition.length} new nodes need positions`);
-      const fastLayoutNodes = getFastLayoutedNodes(renderGraphSnapshot.nodes, direction);
-      const fastPositionMap = new Map(fastLayoutNodes.map((node) => [node.id, node.position]));
-
-      return renderGraphSnapshot.nodes.map((node) => {
-        const existingPosition = positionMap.get(node.id);
-        if (existingPosition) {
-          return { ...node, position: existingPosition };
-        }
-        // Use fast layout position for new nodes instead of (0,0)
-        const fastPosition = fastPositionMap.get(node.id);
-        return { ...node, position: fastPosition ?? { x: 0, y: 0 } };
-      });
-    });
+    setNodes((currentNodes) =>
+      prepareProgressiveLayoutNodes(currentNodes, renderGraphSnapshot.nodes, direction)
+    );
     setEdges(renderGraphSnapshot.edges);
     if (GRAPH_DEBUG) console.timeEnd('[Layout] Stage 1: preserve positions');
 
@@ -857,31 +506,11 @@ export function GraphView({
       return;
     }
 
-    const hasRenderData = layoutedNodes.every((node) => renderNodeDataById.has(node.id));
+    const hasRenderData = layoutedNodes.every((node) => renderGraphIndex.nodeDataById.has(node.id));
     if (!hasRenderData) {
       if (GRAPH_DEBUG) console.timeEnd('[Layout] Stage 2: apply layout positions');
       return;
     }
-
-    const applyRenderDataToNode = (node: FlowNode): FlowNode => {
-      const renderData = renderNodeDataById.get(node.id);
-      if (!renderData || node.data === renderData) return node;
-      return { ...node, data: renderData };
-    };
-
-    const applyRenderDataToEdge = (edge: FlowEdge): FlowEdge => {
-      const renderEdge = renderEdgeById.get(edge.id);
-      if (!renderEdge || edge === renderEdge) return edge;
-      return {
-        ...edge,
-        type: renderEdge.type,
-        label: renderEdge.label,
-        animated: renderEdge.animated,
-        zIndex: renderEdge.zIndex,
-        data: renderEdge.data,
-        style: renderEdge.style,
-      };
-    };
 
     // Note: The layoutIsStale check was removed because it's incompatible with
     // async Web Worker layout. With async layout, layoutedNodes always reflects
@@ -895,12 +524,10 @@ export function GraphView({
       layoutSnapshot.defaultCollapsed !== lastAppliedDefaultCollapsed.current;
 
     // Check if any individual node's collapse state changed (affects node height/layout)
-    const nodeCollapseChanged = layoutedNodes.some((node) => {
-      if (!isTableNodeData(node.data)) return false;
-      const currentCollapsed = node.data.isCollapsed ?? false;
-      const lastCollapsed = lastAppliedCollapseStates.current.get(node.id);
-      return lastCollapsed !== undefined && lastCollapsed !== currentCollapsed;
-    });
+    const nodeCollapseChanged = hasNodeCollapseChanged(
+      layoutedNodes,
+      lastAppliedCollapseStates.current
+    );
 
     // Trigger full layout reapplication when view-affecting settings change
     const needsFullUpdate =
@@ -913,8 +540,8 @@ export function GraphView({
       nodeCollapseChanged;
 
     if (needsFullUpdate) {
-      setNodes(layoutedNodes.map(applyRenderDataToNode));
-      setEdges(layoutedEdges.map(applyRenderDataToEdge));
+      setNodes(applyRenderDataToNodes(layoutedNodes, renderGraphIndex.nodeDataById));
+      setEdges(applyRenderDataToEdges(layoutedEdges, renderGraphIndex.edgeById));
       isInitialized.current = true;
       lastResultId.current = currentResultId;
       lastViewMode.current = layoutSnapshot.viewMode;
@@ -923,28 +550,16 @@ export function GraphView({
       lastAppliedDefaultCollapsed.current = layoutSnapshot.defaultCollapsed;
     } else {
       // Preserve user-adjusted positions while updating node data
-      setNodes((currentNodes) => {
-        return layoutedNodes.map((layoutNode) => {
-          const currentNode = currentNodes.find((n) => n.id === layoutNode.id);
-          if (currentNode) {
-            return applyRenderDataToNode({ ...layoutNode, position: currentNode.position });
-          }
-          return applyRenderDataToNode(layoutNode);
-        });
-      });
-      setEdges(layoutedEdges.map(applyRenderDataToEdge));
+      setNodes((currentNodes) =>
+        applyRenderDataToNodes(layoutedNodes, renderGraphIndex.nodeDataById, currentNodes)
+      );
+      setEdges(applyRenderDataToEdges(layoutedEdges, renderGraphIndex.edgeById));
     }
 
     // Update tracked collapse states
-    const newCollapseStates = new Map<string, boolean>();
-    for (const node of layoutedNodes) {
-      if (isTableNodeData(node.data)) {
-        newCollapseStates.set(node.id, node.data.isCollapsed ?? false);
-      }
-    }
-    lastAppliedCollapseStates.current = newCollapseStates;
+    lastAppliedCollapseStates.current = getNodeCollapseStates(layoutedNodes);
     if (GRAPH_DEBUG) console.timeEnd('[Layout] Stage 2: apply layout positions');
-  }, [layoutedNodes, layoutedEdges, renderNodeDataById, renderEdgeById, setNodes, setEdges]);
+  }, [layoutedNodes, layoutedEdges, renderGraphIndex, setNodes, setEdges]);
 
   const internalGraphRef = useRef<HTMLDivElement>(null);
   const finalRef = graphContainerRef || internalGraphRef;
@@ -1210,79 +825,21 @@ export function GraphView({
         <RevealHandler applyPulse={applyRevealPulse} />
         <ViewportHandler initialViewport={initialViewport} onViewportChange={onViewportChange} />
         <FitViewHandler trigger={fitViewTrigger} />
-        <Background />
-        <Controls />
-        <Panel position="top-left" className="flex gap-3 items-start">
-          <ViewModeSelector />
-          {viewMode === 'script' && (
-            <ToolbarToggleButton
-              isActive={showScriptTables}
-              onClick={actions.toggleShowScriptTables}
-              ariaLabel="Toggle table details"
-              tooltip={showScriptTables ? 'Hide tables' : 'Show tables'}
-              icon={<LayoutList className="size-4" strokeWidth={showScriptTables ? 2.5 : 1.5} />}
-            />
-          )}
-          <GraphSearchControl
-            searchTerm={effectiveSearchTerm ?? ''}
-            onSearchTermChange={handleSearchTermChange}
-            searchableTypes={searchableTypes}
-            focusMode={focusMode}
-            onFocusModeChange={handleFocusModeChange}
-          />
-          {viewMode !== 'script' && (
-            <ToolbarToggleButton
-              isActive={!defaultCollapsed}
-              onClick={() => actions.setAllNodesCollapsed(!defaultCollapsed)}
-              ariaLabel={defaultCollapsed ? 'Expand all tables' : 'Collapse all tables'}
-              tooltip={defaultCollapsed ? 'Expand all tables' : 'Collapse all tables'}
-              icon={
-                defaultCollapsed ? (
-                  <Maximize2 className="size-4" strokeWidth={1.5} />
-                ) : (
-                  <Minimize2 className="size-4" strokeWidth={1.5} />
-                )
-              }
-            />
-          )}
-          {viewMode !== 'script' && (
-            <ToolbarToggleButton
-              isActive={showColumnEdges}
-              onClick={actions.toggleColumnEdges}
-              ariaLabel={showColumnEdges ? 'Show table connections' : 'Show column lineage'}
-              tooltip={showColumnEdges ? 'Show table connections' : 'Show column lineage'}
-              icon={
-                showColumnEdges ? (
-                  <GitBranch className="size-4" strokeWidth={1.5} />
-                ) : (
-                  <Route className="size-4" strokeWidth={1.5} />
-                )
-              }
-            />
-          )}
-          {viewMode !== 'script' && <TableFilterDropdown />}
-        </Panel>
-        <Panel position="top-right" className="flex gap-3 items-start">
-          <Legend viewMode={viewMode} />
-          <LayoutSelector />
-        </Panel>
-        <Panel position="bottom-left" className="!m-3">
-          <LayoutProgressIndicator />
-        </Panel>
-        {showMiniMap && (
-          <MiniMap
-            nodeColor={(node) => {
-              if (isTableNodeData(node.data)) {
-                return getMinimapNodeColor(node.data.nodeType || 'table');
-              }
-              // For script nodes, check node type from id prefix
-              if (node.id.startsWith('script:')) {
-                return getMinimapNodeColor('script');
-              }
-              return getMinimapNodeColor('table');
-            }}
-          />
-        )}
+        <GraphViewControls
+          viewMode={viewMode}
+          showScriptTables={showScriptTables}
+          defaultCollapsed={defaultCollapsed}
+          showColumnEdges={showColumnEdges}
+          searchTerm={effectiveSearchTerm ?? ''}
+          searchableTypes={searchableTypes}
+          focusMode={focusMode}
+          showMiniMap={showMiniMap}
+          onSearchTermChange={handleSearchTermChange}
+          onFocusModeChange={handleFocusModeChange}
+          onToggleShowScriptTables={actions.toggleShowScriptTables}
+          onSetAllNodesCollapsed={actions.setAllNodesCollapsed}
+          onToggleColumnEdges={actions.toggleColumnEdges}
+        />
       </ReactFlow>
     </div>
   );

--- a/packages/react/src/components/GraphViewControls.tsx
+++ b/packages/react/src/components/GraphViewControls.tsx
@@ -1,0 +1,184 @@
+import type { JSX, ReactNode } from 'react';
+import { Background, Controls, MiniMap, Panel } from '@xyflow/react';
+import { GitBranch, LayoutList, Maximize2, Minimize2, Route } from 'lucide-react';
+
+import { getMinimapNodeColor, PANEL_STYLES } from '../constants';
+import type { SearchableType } from '../hooks/useSearchSuggestions';
+import type { LineageViewMode } from '../types';
+import { isTableNodeData } from '../utils/graphTraversal';
+import { GraphSearchControl } from './GraphSearchControl';
+import { LayoutProgressIndicator } from './LayoutProgressIndicator';
+import { LayoutSelector } from './LayoutSelector';
+import { Legend } from './Legend';
+import { TableFilterDropdown } from './TableFilterDropdown';
+import { ViewModeSelector } from './ViewModeSelector';
+import {
+  GraphTooltip,
+  GraphTooltipArrow,
+  GraphTooltipContent,
+  GraphTooltipPortal,
+  GraphTooltipProvider,
+  GraphTooltipTrigger,
+} from './ui/graph-tooltip';
+
+interface ToolbarToggleButtonProps {
+  isActive: boolean;
+  onClick: () => void;
+  ariaLabel: string;
+  tooltip: string;
+  icon: ReactNode;
+}
+
+/**
+ * Reusable toggle button for graph toolbar actions.
+ * Provides consistent styling and tooltip behavior.
+ */
+function ToolbarToggleButton({
+  isActive,
+  onClick,
+  ariaLabel,
+  tooltip,
+  icon,
+}: ToolbarToggleButtonProps): JSX.Element {
+  return (
+    <div className={PANEL_STYLES.container} data-graph-panel>
+      <GraphTooltipProvider>
+        <GraphTooltip delayDuration={300}>
+          <GraphTooltipTrigger asChild>
+            <button
+              onClick={onClick}
+              className={`
+                inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full transition-all duration-200
+                ${isActive ? 'bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100' : 'text-slate-500 hover:text-slate-700 dark:hover:text-slate-300'}
+                focus-visible:outline-hidden
+              `}
+              aria-label={ariaLabel}
+              aria-pressed={isActive}
+            >
+              {icon}
+            </button>
+          </GraphTooltipTrigger>
+          <GraphTooltipPortal>
+            <GraphTooltipContent side="bottom">
+              <p>{tooltip}</p>
+              <GraphTooltipArrow />
+            </GraphTooltipContent>
+          </GraphTooltipPortal>
+        </GraphTooltip>
+      </GraphTooltipProvider>
+    </div>
+  );
+}
+
+export interface GraphViewControlsProps {
+  viewMode: LineageViewMode;
+  showScriptTables: boolean;
+  defaultCollapsed: boolean;
+  showColumnEdges: boolean;
+  searchTerm: string;
+  searchableTypes: SearchableType[];
+  focusMode: boolean;
+  showMiniMap: boolean;
+  onSearchTermChange: (searchTerm: string) => void;
+  onFocusModeChange: (enabled: boolean) => void;
+  onToggleShowScriptTables: () => void;
+  onSetAllNodesCollapsed: (collapsed: boolean) => void;
+  onToggleColumnEdges: () => void;
+}
+
+/**
+ * Presentation-only controls rendered inside the ReactFlow canvas.
+ */
+export function GraphViewControls({
+  viewMode,
+  showScriptTables,
+  defaultCollapsed,
+  showColumnEdges,
+  searchTerm,
+  searchableTypes,
+  focusMode,
+  showMiniMap,
+  onSearchTermChange,
+  onFocusModeChange,
+  onToggleShowScriptTables,
+  onSetAllNodesCollapsed,
+  onToggleColumnEdges,
+}: GraphViewControlsProps): JSX.Element {
+  return (
+    <>
+      <Background />
+      <Controls />
+      <Panel position="top-left" className="flex gap-3 items-start">
+        <ViewModeSelector />
+        {viewMode === 'script' && (
+          <ToolbarToggleButton
+            isActive={showScriptTables}
+            onClick={onToggleShowScriptTables}
+            ariaLabel="Toggle table details"
+            tooltip={showScriptTables ? 'Hide tables' : 'Show tables'}
+            icon={<LayoutList className="size-4" strokeWidth={showScriptTables ? 2.5 : 1.5} />}
+          />
+        )}
+        <GraphSearchControl
+          searchTerm={searchTerm}
+          onSearchTermChange={onSearchTermChange}
+          searchableTypes={searchableTypes}
+          focusMode={focusMode}
+          onFocusModeChange={onFocusModeChange}
+        />
+        {viewMode !== 'script' && (
+          <ToolbarToggleButton
+            isActive={!defaultCollapsed}
+            onClick={() => onSetAllNodesCollapsed(!defaultCollapsed)}
+            ariaLabel={defaultCollapsed ? 'Expand all tables' : 'Collapse all tables'}
+            tooltip={defaultCollapsed ? 'Expand all tables' : 'Collapse all tables'}
+            icon={
+              defaultCollapsed ? (
+                <Maximize2 className="size-4" strokeWidth={1.5} />
+              ) : (
+                <Minimize2 className="size-4" strokeWidth={1.5} />
+              )
+            }
+          />
+        )}
+        {viewMode !== 'script' && (
+          <ToolbarToggleButton
+            isActive={showColumnEdges}
+            onClick={onToggleColumnEdges}
+            ariaLabel={showColumnEdges ? 'Show table connections' : 'Show column lineage'}
+            tooltip={showColumnEdges ? 'Show table connections' : 'Show column lineage'}
+            icon={
+              showColumnEdges ? (
+                <GitBranch className="size-4" strokeWidth={1.5} />
+              ) : (
+                <Route className="size-4" strokeWidth={1.5} />
+              )
+            }
+          />
+        )}
+        {viewMode !== 'script' && <TableFilterDropdown />}
+      </Panel>
+      <Panel position="top-right" className="flex gap-3 items-start">
+        <Legend viewMode={viewMode} />
+        <LayoutSelector />
+      </Panel>
+      <Panel position="bottom-left" className="!m-3">
+        <LayoutProgressIndicator />
+      </Panel>
+      {showMiniMap && (
+        <MiniMap
+          nodeColor={(node) => {
+            if (isTableNodeData(node.data)) {
+              return getMinimapNodeColor(node.data.nodeType || 'table');
+            }
+            // For script nodes, check node type from id prefix
+            if (node.id.startsWith('script:')) {
+              return getMinimapNodeColor('script');
+            }
+            return getMinimapNodeColor('table');
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/react/src/components/GraphViewHandlers.tsx
+++ b/packages/react/src/components/GraphViewHandlers.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef } from 'react';
+import { useReactFlow } from '@xyflow/react';
+import type { Viewport } from '@xyflow/react';
+
+import { NODE_FOCUS_DELAY_MS } from '../constants';
+import { useNodeFocus } from '../hooks/useNodeFocus';
+import { useLineageStore } from '../store';
+
+/**
+ * Helper component to handle node focusing.
+ * Must be rendered inside ReactFlow to access useReactFlow hook.
+ */
+export function NodeFocusHandler({
+  focusNodeId,
+  onFocusApplied,
+}: {
+  focusNodeId?: string;
+  onFocusApplied?: () => void;
+}): null {
+  useNodeFocus({ focusNodeId, onFocusApplied });
+  return null;
+}
+
+/**
+ * Watches the store's `revealRequest` and drives both the graph's fitView
+ * animation and the transient pulse class on the target node. A nonce is used
+ * instead of a plain node id so re-revealing the same node restarts the
+ * animation.
+ */
+export function RevealHandler({ applyPulse }: { applyPulse: (nodeId: string) => void }): null {
+  const revealRequest = useLineageStore((store) => store.revealRequest);
+  const clearRevealRequest = useLineageStore((store) => store.clearRevealRequest);
+  const { fitView, getNode } = useReactFlow();
+  const lastNonceRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!revealRequest) {
+      lastNonceRef.current = null;
+      return;
+    }
+    if (revealRequest.nonce === lastNonceRef.current) return;
+    lastNonceRef.current = revealRequest.nonce;
+
+    // ReactFlow needs a tick to render newly-selected nodes before we can
+    // query their positions (same reason `useNodeFocus` uses NODE_FOCUS_DELAY_MS).
+    const timer = setTimeout(() => {
+      const node = getNode(revealRequest.nodeId);
+      if (node) {
+        fitView({ nodes: [{ id: revealRequest.nodeId }], duration: 500, padding: 0.5 });
+        applyPulse(revealRequest.nodeId);
+      }
+      clearRevealRequest();
+    }, NODE_FOCUS_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [revealRequest, fitView, getNode, applyPulse, clearRevealRequest]);
+
+  return null;
+}
+
+/**
+ * Helper component to trigger fitView when fitViewTrigger changes.
+ * Must be rendered inside ReactFlow to access useReactFlow hook.
+ */
+export function FitViewHandler({ trigger }: { trigger?: number }): null {
+  const { fitView } = useReactFlow();
+  const lastTriggerRef = useRef(trigger);
+
+  useEffect(() => {
+    if (trigger !== undefined && trigger !== lastTriggerRef.current) {
+      lastTriggerRef.current = trigger;
+      // Small delay to ensure nodes are rendered
+      setTimeout(() => {
+        fitView({ padding: 0.2, duration: 200 });
+      }, 50);
+    }
+  }, [trigger, fitView]);
+
+  return null;
+}
+
+/**
+ * Helper component to handle viewport changes and restoration.
+ * Must be rendered inside ReactFlow to access useReactFlow hook.
+ */
+export function ViewportHandler({
+  initialViewport,
+  onViewportChange,
+}: {
+  initialViewport?: Viewport;
+  onViewportChange?: (viewport: Viewport) => void;
+}): null {
+  const { setViewport, getViewport } = useReactFlow();
+  const hasRestoredRef = useRef(false);
+  const previousInitialViewportRef = useRef<Viewport | undefined>(initialViewport);
+  const viewportChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (viewportChangeTimerRef.current) {
+        clearTimeout(viewportChangeTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Reset restoration flag when initial viewport changes (e.g., project switch)
+  useEffect(() => {
+    if (previousInitialViewportRef.current !== initialViewport) {
+      hasRestoredRef.current = false;
+      previousInitialViewportRef.current = initialViewport;
+    }
+  }, [initialViewport]);
+
+  // Restore initial viewport as needed
+  useEffect(() => {
+    if (initialViewport && !hasRestoredRef.current) {
+      // Delay to ensure ReactFlow is ready
+      const timer = setTimeout(() => {
+        setViewport(initialViewport, { duration: 0 });
+        hasRestoredRef.current = true;
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [initialViewport, setViewport]);
+
+  // Debounced viewport change callback
+  useEffect(() => {
+    if (!onViewportChange) return;
+
+    const handleViewportChange = () => {
+      if (viewportChangeTimerRef.current) {
+        clearTimeout(viewportChangeTimerRef.current);
+      }
+      viewportChangeTimerRef.current = setTimeout(() => {
+        const viewport = getViewport();
+        onViewportChange(viewport);
+      }, 300);
+    };
+
+    // Use MutationObserver on the viewport's style attribute rather than ReactFlow's
+    // onMove/onViewportChange events. Those events fire at very high frequency during
+    // pan/zoom operations which would cause excessive state updates and re-renders.
+    // The MutationObserver approach with debouncing provides more reliable, batched updates.
+    const container = document.querySelector('.react-flow__viewport');
+    if (container) {
+      const observer = new MutationObserver(handleViewportChange);
+      observer.observe(container, { attributes: true, attributeFilter: ['style'] });
+      return () => {
+        observer.disconnect();
+        if (viewportChangeTimerRef.current) {
+          clearTimeout(viewportChangeTimerRef.current);
+        }
+      };
+    }
+  }, [onViewportChange, getViewport]);
+
+  return null;
+}

--- a/packages/react/src/utils/graphViewModel.ts
+++ b/packages/react/src/utils/graphViewModel.ts
@@ -1,0 +1,217 @@
+import type { Edge as FlowEdge, Node as FlowNode } from '@xyflow/react';
+
+import { GRAPH_CONFIG } from '../constants';
+import type { LineageViewMode } from '../types';
+import type { SearchableType } from '../hooks/useSearchSuggestions';
+import { getFastLayoutedNodes } from './layout';
+import { isTableNodeData } from './graphTraversal';
+
+const MINIMAP_NODE_LIMIT = 2000;
+
+/**
+ * Threshold for determining when to treat a graph as "new" vs "evolved".
+ * If fewer than this fraction of nodes have existing positions, we use
+ * fast layout for all nodes instead of preserving positions.
+ */
+const NODE_OVERLAP_THRESHOLD = 0.5;
+
+export interface GraphElements {
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+}
+
+export interface RenderGraphIndex {
+  nodeDataById: Map<string, FlowNode['data']>;
+  edgeById: Map<string, FlowEdge>;
+}
+
+interface SelectableNodeData {
+  isSelected?: boolean;
+  [key: string]: unknown;
+}
+
+function isSelectableNodeData(data: unknown): data is SelectableNodeData {
+  return typeof data === 'object' && data !== null;
+}
+
+export function getGraphSearchableTypes(
+  viewMode: LineageViewMode,
+  showColumnEdges: boolean
+): SearchableType[] {
+  if (viewMode === 'script') {
+    return ['script', 'table', 'view', 'cte'];
+  }
+
+  return showColumnEdges
+    ? ['table', 'view', 'cte', 'column', 'script']
+    : ['table', 'view', 'cte', 'script'];
+}
+
+export function enhanceGraphWithHighlights(
+  graph: GraphElements,
+  highlightIds: ReadonlySet<string>
+): GraphElements {
+  const nodes = graph.nodes.map((node) => {
+    const isHighlighted = highlightIds.has(node.id);
+
+    if (isTableNodeData(node.data)) {
+      const nodeData = node.data;
+      const columns = nodeData.columns.map((column) => ({
+        ...column,
+        isHighlighted: highlightIds.has(column.id),
+      }));
+
+      return {
+        ...node,
+        data: {
+          ...nodeData,
+          columns,
+          isSelected: nodeData.isSelected || isHighlighted,
+        },
+      };
+    }
+
+    const currentIsSelected = isSelectableNodeData(node.data) ? node.data.isSelected : false;
+    return {
+      ...node,
+      data: {
+        ...node.data,
+        isSelected: currentIsSelected || isHighlighted,
+      },
+    };
+  });
+
+  const edges = graph.edges.map((edge) => {
+    const isHighlighted = highlightIds.has(edge.id);
+    return {
+      ...edge,
+      animated: isHighlighted,
+      zIndex: isHighlighted ? GRAPH_CONFIG.HIGHLIGHTED_EDGE_Z_INDEX : 0,
+      data: {
+        ...edge.data,
+        isHighlighted,
+      },
+    };
+  });
+
+  return { nodes, edges };
+}
+
+export function createRenderGraphIndex(graph: GraphElements): RenderGraphIndex {
+  return {
+    nodeDataById: new Map(graph.nodes.map((node) => [node.id, node.data])),
+    edgeById: new Map(graph.edges.map((edge) => [edge.id, edge])),
+  };
+}
+
+export function prepareProgressiveLayoutNodes(
+  currentNodes: FlowNode[],
+  renderNodes: FlowNode[],
+  direction: 'LR' | 'TB'
+): FlowNode[] {
+  if (currentNodes.length === 0) {
+    return getFastLayoutedNodes(renderNodes, direction);
+  }
+
+  const positionById = new Map(currentNodes.map((node) => [node.id, node.position]));
+  const nodesWithoutPosition = renderNodes.filter((node) => !positionById.has(node.id));
+  const matchCount = renderNodes.length - nodesWithoutPosition.length;
+
+  if (matchCount < renderNodes.length * NODE_OVERLAP_THRESHOLD) {
+    return getFastLayoutedNodes(renderNodes, direction);
+  }
+
+  if (nodesWithoutPosition.length === 0) {
+    return renderNodes.map((node) => ({
+      ...node,
+      position: positionById.get(node.id)!,
+    }));
+  }
+
+  const fastLayoutNodes = getFastLayoutedNodes(renderNodes, direction);
+  const fastPositionById = new Map(fastLayoutNodes.map((node) => [node.id, node.position]));
+
+  return renderNodes.map((node) => ({
+    ...node,
+    position: positionById.get(node.id) ?? fastPositionById.get(node.id) ?? { x: 0, y: 0 },
+  }));
+}
+
+export function applyRenderDataToNodes(
+  nodes: FlowNode[],
+  nodeDataById: RenderGraphIndex['nodeDataById'],
+  currentNodes?: FlowNode[]
+): FlowNode[] {
+  const currentPositionById = currentNodes
+    ? new Map(currentNodes.map((node) => [node.id, node.position]))
+    : null;
+
+  return nodes.map((node) => {
+    const renderData = nodeDataById.get(node.id);
+    const currentPosition = currentPositionById?.get(node.id);
+
+    if (currentPosition) {
+      return {
+        ...node,
+        position: currentPosition,
+        data: renderData ?? node.data,
+      };
+    }
+
+    if (!renderData || node.data === renderData) {
+      return node;
+    }
+
+    return {
+      ...node,
+      data: renderData,
+    };
+  });
+}
+
+export function applyRenderDataToEdges(
+  edges: FlowEdge[],
+  edgeById: RenderGraphIndex['edgeById']
+): FlowEdge[] {
+  return edges.map((edge) => {
+    const renderEdge = edgeById.get(edge.id);
+    if (!renderEdge || edge === renderEdge) return edge;
+
+    return {
+      ...edge,
+      type: renderEdge.type,
+      label: renderEdge.label,
+      animated: renderEdge.animated,
+      zIndex: renderEdge.zIndex,
+      data: renderEdge.data,
+      style: renderEdge.style,
+    };
+  });
+}
+
+export function hasNodeCollapseChanged(
+  nodes: FlowNode[],
+  previousCollapseStates: ReadonlyMap<string, boolean>
+): boolean {
+  return nodes.some((node) => {
+    if (!isTableNodeData(node.data)) return false;
+    const previousCollapsed = previousCollapseStates.get(node.id);
+    return (
+      previousCollapsed !== undefined && previousCollapsed !== (node.data.isCollapsed ?? false)
+    );
+  });
+}
+
+export function getNodeCollapseStates(nodes: FlowNode[]): Map<string, boolean> {
+  const collapseStates = new Map<string, boolean>();
+  for (const node of nodes) {
+    if (isTableNodeData(node.data)) {
+      collapseStates.set(node.id, node.data.isCollapsed ?? false);
+    }
+  }
+  return collapseStates;
+}
+
+export function shouldShowMiniMap(nodeCount: number): boolean {
+  return nodeCount > 0 && nodeCount <= MINIMAP_NODE_LIMIT;
+}

--- a/packages/react/tests/graphViewModel.test.ts
+++ b/packages/react/tests/graphViewModel.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import type { Edge as FlowEdge, Node as FlowNode } from '@xyflow/react';
+
+import { GRAPH_CONFIG } from '../src/constants';
+import type { TableNodeData } from '../src/types';
+import {
+  applyRenderDataToEdges,
+  applyRenderDataToNodes,
+  createRenderGraphIndex,
+  enhanceGraphWithHighlights,
+  getGraphSearchableTypes,
+  getNodeCollapseStates,
+  hasNodeCollapseChanged,
+  prepareProgressiveLayoutNodes,
+  shouldShowMiniMap,
+} from '../src/utils/graphViewModel';
+
+function makeNode(id: string, data: Record<string, unknown> = {}): FlowNode {
+  return { id, position: { x: 0, y: 0 }, data };
+}
+
+function makeTableNode(id: string, isCollapsed = false): FlowNode {
+  return {
+    id,
+    type: 'tableNode',
+    position: { x: 0, y: 0 },
+    data: {
+      label: id,
+      nodeType: 'table',
+      columns: [
+        { id: `${id}:highlighted`, name: 'highlighted' },
+        { id: `${id}:plain`, name: 'plain' },
+      ],
+      isSelected: false,
+      isCollapsed,
+      isHighlighted: false,
+    } satisfies TableNodeData,
+  };
+}
+
+describe('enhanceGraphWithHighlights', () => {
+  it('projects highlighted graph ids into table columns, nodes, and edges', () => {
+    const tableNode = makeTableNode('table:orders');
+    const scriptNode = makeNode('script:load', { label: 'load', isSelected: true });
+    const edge: FlowEdge = {
+      id: 'edge:orders-load',
+      source: tableNode.id,
+      target: scriptNode.id,
+      data: { relation: 'read' },
+    };
+
+    const result = enhanceGraphWithHighlights(
+      { nodes: [tableNode, scriptNode], edges: [edge] },
+      new Set([tableNode.id, 'table:orders:highlighted', edge.id])
+    );
+
+    const tableData = result.nodes[0].data as TableNodeData;
+    expect(tableData.isSelected).toBe(true);
+    expect(tableData.columns.map((column) => column.isHighlighted)).toEqual([true, false]);
+    expect(result.nodes[1].data.isSelected).toBe(true);
+    expect(result.edges[0]).toMatchObject({
+      animated: true,
+      zIndex: GRAPH_CONFIG.HIGHLIGHTED_EDGE_Z_INDEX,
+      data: { relation: 'read', isHighlighted: true },
+    });
+  });
+
+  it('clears transient edge highlights without clearing existing node selection', () => {
+    const selectedNode = makeNode('script:selected', { isSelected: true });
+    const edge: FlowEdge = { id: 'edge', source: 'a', target: 'b', animated: true, zIndex: 10 };
+
+    const result = enhanceGraphWithHighlights({ nodes: [selectedNode], edges: [edge] }, new Set());
+
+    expect(result.nodes[0].data.isSelected).toBe(true);
+    expect(result.edges[0]).toMatchObject({
+      animated: false,
+      zIndex: 0,
+      data: { isHighlighted: false },
+    });
+  });
+});
+
+describe('prepareProgressiveLayoutNodes', () => {
+  it('preserves every position when the graph ids are unchanged', () => {
+    const current = [
+      { ...makeNode('a'), position: { x: 100, y: 200 } },
+      { ...makeNode('b'), position: { x: 300, y: 400 } },
+    ];
+    const render = [makeNode('a', { version: 2 }), makeNode('b', { version: 2 })];
+
+    const result = prepareProgressiveLayoutNodes(current, render, 'LR');
+
+    expect(result.map((node) => node.position)).toEqual(current.map((node) => node.position));
+    expect(result.map((node) => node.data)).toEqual(render.map((node) => node.data));
+  });
+
+  it('uses a fresh fast layout when fewer than half of the node ids overlap', () => {
+    const current = [{ ...makeNode('a'), position: { x: 999, y: 999 } }];
+    const render = [makeNode('a'), makeNode('b'), makeNode('c')];
+
+    const result = prepareProgressiveLayoutNodes(current, render, 'LR');
+
+    expect(result[0].position).not.toEqual(current[0].position);
+  });
+
+  it('preserves matched positions and lays out new nodes at the overlap threshold', () => {
+    const current = [{ ...makeNode('a'), position: { x: 999, y: 999 } }];
+    const render = [makeNode('a'), makeNode('b')];
+
+    const result = prepareProgressiveLayoutNodes(current, render, 'LR');
+
+    expect(result[0].position).toEqual(current[0].position);
+    expect(result[1].position).not.toEqual(current[0].position);
+  });
+});
+
+describe('render graph reconciliation', () => {
+  it('applies current render data while preserving user-adjusted positions', () => {
+    const layoutNode = makeNode('a', { version: 'layout' });
+    const renderNode = makeNode('a', { version: 'render' });
+    const currentNode = { ...makeNode('a'), position: { x: 25, y: 50 } };
+    const layoutEdge: FlowEdge = { id: 'edge', source: 'a', target: 'b', animated: false };
+    const renderEdge: FlowEdge = {
+      ...layoutEdge,
+      animated: true,
+      zIndex: 100,
+      data: { isHighlighted: true },
+    };
+    const index = createRenderGraphIndex({ nodes: [renderNode], edges: [renderEdge] });
+
+    expect(applyRenderDataToNodes([layoutNode], index.nodeDataById, [currentNode])).toEqual([
+      { ...layoutNode, position: currentNode.position, data: renderNode.data },
+    ]);
+    expect(applyRenderDataToEdges([layoutEdge], index.edgeById)).toEqual([renderEdge]);
+  });
+
+  it('tracks table collapse state changes without including other node types', () => {
+    const collapsed = makeTableNode('table:orders', true);
+    const script = makeNode('script:load', { isCollapsed: true });
+
+    const collapseStates = getNodeCollapseStates([collapsed, script]);
+
+    expect(collapseStates).toEqual(new Map([[collapsed.id, true]]));
+    expect(hasNodeCollapseChanged([collapsed], new Map([[collapsed.id, false]]))).toBe(true);
+    expect(hasNodeCollapseChanged([collapsed], collapseStates)).toBe(false);
+  });
+});
+
+describe('graph control derivation', () => {
+  it('derives searchable types from view and column settings', () => {
+    expect(getGraphSearchableTypes('script', true)).toEqual(['script', 'table', 'view', 'cte']);
+    expect(getGraphSearchableTypes('table', false)).toEqual(['table', 'view', 'cte', 'script']);
+    expect(getGraphSearchableTypes('table', true)).toContain('column');
+  });
+
+  it('shows the minimap only for non-empty graphs within the supported size', () => {
+    expect(shouldShowMiniMap(0)).toBe(false);
+    expect(shouldShowMiniMap(1)).toBe(true);
+    expect(shouldShowMiniMap(2000)).toBe(true);
+    expect(shouldShowMiniMap(2001)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- extract ReactFlow lifecycle adapters into `GraphViewHandlers`
- extract canvas controls and minimap presentation into `GraphViewControls`
- move highlight projection, progressive layout preparation, and render reconciliation into a pure `graphViewModel` module
- add focused tests for the extracted transformation and layout branches

`GraphView.tsx` drops from 1,289 lines to 846 lines (443 lines, 34%). Its remaining responsibility is graph build/layout orchestration and navigation coordination.

## Scope

This is a focused first refactor of the highest-priority hotspot. It preserves the exported `GraphView` API, existing control markup and styling, worker/layout effect timing, and navigation behavior. `MatrixView` and the Rust CLI fixer remain unchanged for later work.

## Validation

- `yarn workspace @pondpilot/flowscope-react test` — 16 files, 204 tests passed
- `yarn workspace @pondpilot/flowscope-react typecheck`
- `yarn workspace @pondpilot/flowscope-react lint`
- `yarn workspace @pondpilot/flowscope-react build`

## Residual risk

The pure graph and layout transitions now have direct coverage. ReactFlow timer, viewport, and worker orchestration behavior still relies on the existing package suite; this PR moves those adapters without changing their implementation.