### PR TITLE
fix(app): key analysis cache by semantic inputs

### DIFF
--- a/app/src/hooks/__tests__/useAnalysis.test.tsx
+++ b/app/src/hooks/__tests__/useAnalysis.test.tsx
@@ -1,0 +1,183 @@
+import type { AnalyzeResult } from '@pondpilot/flowscope-core';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BackendAdapter } from '@/lib/backend-adapter';
+import { buildAnalysisCacheKey, PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS } from '@/lib/analysis-hash';
+import { useAnalysisStore } from '@/lib/analysis-store';
+import type { Project } from '@/lib/project-store';
+
+const lineageActions = vi.hoisted(() => ({
+  setResult: vi.fn(),
+  setAnalyzedContent: vi.fn(),
+  setStalePaths: vi.fn(),
+  setSql: vi.fn(),
+}));
+
+let currentProject: Project | null = null;
+let activeProjectId: string | null = null;
+
+vi.mock('@pondpilot/flowscope-react', () => ({
+  useLineage: () => ({
+    state: { hideCTEs: false },
+    actions: lineageActions,
+  }),
+}));
+
+vi.mock('@/lib/project-store', () => ({
+  useProject: () => ({ currentProject, activeProjectId, backendSchema: null }),
+}));
+
+vi.mock('@/lib/view-state-store', () => ({
+  useViewStateStore: (selector: (state: { getViewState: () => undefined }) => unknown) =>
+    selector({ getViewState: () => undefined }),
+  getIssuesStateWithDefaults: () => ({ showLintIssues: false }),
+}));
+
+import { useAnalysis } from '../useAnalysis';
+
+const cachedResult = {
+  nodes: [],
+  edges: [],
+  statements: [],
+  issues: [],
+} as unknown as AnalyzeResult;
+
+function createProject(id: string, content: string): Project {
+  return {
+    id,
+    name: id,
+    files: [
+      {
+        id: `${id}-file`,
+        name: 'model.sql',
+        path: 'model.sql',
+        content,
+        language: 'sql',
+      },
+    ],
+    activeFileId: `${id}-file`,
+    dialect: 'generic',
+    runMode: 'all',
+    selectedFileIds: [],
+    schemaSQL: '',
+    templateMode: 'raw',
+  };
+}
+
+function buildProjectCacheKey(project: Project): string {
+  const file = project.files[0];
+  return buildAnalysisCacheKey({
+    files: [{ name: file.path, content: file.content }],
+    dialect: project.dialect,
+    schemaSQL: project.schemaSQL,
+    hideCTEs: false,
+    enableColumnLineage: true,
+    enableLinting: false,
+    templateMode: project.templateMode,
+  });
+}
+
+function createAdapter(analyze = vi.fn()): BackendAdapter {
+  return {
+    type: 'wasm',
+    initialize: vi.fn(),
+    analyze,
+    getCached: vi.fn().mockResolvedValue(null),
+    getVersion: vi.fn().mockResolvedValue(null),
+    syncFiles: vi.fn().mockResolvedValue(undefined),
+    clearCache: vi.fn(),
+  } as unknown as BackendAdapter;
+}
+
+describe('useAnalysis memory cache', () => {
+  beforeEach(() => {
+    activeProjectId = 'project-1';
+    currentProject = createProject(
+      activeProjectId,
+      'x'.repeat(PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS + 1)
+    );
+    useAnalysisStore.getState().clearAllResults();
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('displays an exact memory hit before accepting a skipped worker response', async () => {
+    const file = currentProject!.files[0];
+    const cacheKey = buildProjectCacheKey(currentProject!);
+    useAnalysisStore.getState().setResult(activeProjectId!, cacheKey, cachedResult);
+
+    const analyze = vi.fn().mockResolvedValue({
+      result: null,
+      cacheKey,
+      cacheHit: true,
+      skipped: true,
+      timings: null,
+    });
+    const adapter = createAdapter(analyze);
+    const { result } = renderHook(() => useAnalysis(true, { adapter }));
+    lineageActions.setResult.mockClear();
+
+    await act(async () => {
+      await result.current.runAnalysis();
+    });
+
+    expect(analyze).toHaveBeenCalledWith(expect.any(Object), { knownCacheKey: cacheKey });
+    expect(lineageActions.setResult).toHaveBeenCalledWith(cachedResult);
+    expect(lineageActions.setAnalyzedContent).toHaveBeenCalledWith(
+      new Map([['model.sql', file.content]])
+    );
+    expect(lineageActions.setStalePaths).toHaveBeenCalledWith([]);
+  });
+
+  it('records the active project while clearing during the no-key debounce window', async () => {
+    vi.useFakeTimers();
+    const projectA = createProject('project-a', 'SELECT 1');
+    const projectB = createProject('project-b', 'SELECT 2');
+    const keyA = buildProjectCacheKey(projectA);
+    activeProjectId = projectA.id;
+    currentProject = projectA;
+    useAnalysisStore.getState().setResult(projectA.id, keyA, cachedResult);
+
+    const adapter = createAdapter();
+    const { rerender } = renderHook(() => useAnalysis(true, { adapter }));
+    expect(lineageActions.setResult).toHaveBeenCalledWith(cachedResult);
+    lineageActions.setResult.mockClear();
+
+    act(() => {
+      activeProjectId = projectB.id;
+      currentProject = projectB;
+      rerender();
+    });
+    expect(lineageActions.setResult).toHaveBeenCalledTimes(1);
+    expect(lineageActions.setResult).toHaveBeenLastCalledWith(null);
+    lineageActions.setResult.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(lineageActions.setResult).not.toHaveBeenCalled();
+
+    act(() => {
+      activeProjectId = projectA.id;
+      currentProject = projectA;
+      rerender();
+    });
+    expect(lineageActions.setResult).toHaveBeenLastCalledWith(null);
+    lineageActions.setResult.mockClear();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(lineageActions.setResult).toHaveBeenCalledWith(cachedResult);
+  });
+});

--- a/app/src/hooks/__tests__/useAnalysis.test.tsx
+++ b/app/src/hooks/__tests__/useAnalysis.test.tsx
@@ -77,9 +77,9 @@ function buildProjectCacheKey(project: Project): string {
   });
 }
 
-function createAdapter(analyze = vi.fn()): BackendAdapter {
+function createAdapter(analyze = vi.fn(), type: BackendAdapter['type'] = 'wasm'): BackendAdapter {
   return {
-    type: 'wasm',
+    type,
     initialize: vi.fn(),
     analyze,
     getCached: vi.fn().mockResolvedValue(null),
@@ -178,6 +178,83 @@ describe('useAnalysis memory cache', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(300);
     });
+    expect(lineageActions.setResult).toHaveBeenCalledWith(cachedResult);
+  });
+
+  it('ignores an old persistent lookup that resolves during the debounce window', async () => {
+    const projectA = createProject('project-1', 'SELECT 1');
+    const projectB = createProject('project-1', 'SELECT 2');
+    const keyA = buildProjectCacheKey(projectA);
+    activeProjectId = projectA.id;
+    currentProject = projectA;
+
+    let resolveLookup!: (value: {
+      result: AnalyzeResult;
+      cacheKey: string;
+      cacheHit: boolean;
+      skipped: boolean;
+      timings: null;
+    }) => void;
+    const lookup = new Promise<Parameters<typeof resolveLookup>[0]>((resolve) => {
+      resolveLookup = resolve;
+    });
+    const adapter = createAdapter();
+    adapter.getCached = vi.fn(() => lookup);
+    const { rerender } = renderHook(() => useAnalysis(true, { adapter }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(adapter.getCached).toHaveBeenCalledTimes(1);
+    lineageActions.setResult.mockClear();
+
+    act(() => {
+      currentProject = projectB;
+      rerender();
+    });
+
+    await act(async () => {
+      resolveLookup({
+        result: cachedResult,
+        cacheKey: keyA,
+        cacheHit: true,
+        skipped: false,
+        timings: null,
+      });
+      await lookup;
+    });
+
+    expect(lineageActions.setResult).not.toHaveBeenCalledWith(cachedResult);
+    expect(useAnalysisStore.getState().getResult(projectA.id, keyA)).toBeNull();
+  });
+
+  it('does not build a canonical cache key for explicit REST analysis', async () => {
+    const charCodeAt = vi.fn(() => {
+      throw new Error('REST content was hashed');
+    });
+    const hashSentinel = {
+      length: PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS + 1,
+      charCodeAt,
+    } as unknown as string;
+    currentProject = createProject('project-1', hashSentinel);
+    activeProjectId = currentProject.id;
+
+    const analyze = vi.fn().mockResolvedValue({
+      result: cachedResult,
+      cacheKey: '',
+      cacheHit: false,
+      skipped: false,
+      timings: null,
+    });
+    const adapter = createAdapter(analyze, 'rest');
+    const { result } = renderHook(() => useAnalysis(true, { adapter }));
+
+    await act(async () => {
+      await result.current.runAnalysis();
+    });
+
+    expect(charCodeAt).not.toHaveBeenCalled();
+    expect(analyze).toHaveBeenCalledTimes(1);
     expect(lineageActions.setResult).toHaveBeenCalledWith(cachedResult);
   });
 });

--- a/app/src/hooks/__tests__/useAnalysis.test.tsx
+++ b/app/src/hooks/__tests__/useAnalysis.test.tsx
@@ -2,7 +2,8 @@ import type { AnalyzeResult } from '@pondpilot/flowscope-core';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BackendAdapter } from '@/lib/backend-adapter';
-import { buildAnalysisCacheKey, PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS } from '@/lib/analysis-hash';
+import { buildAnalysisCacheKey } from '@/lib/analysis-hash';
+import { PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS } from '@/lib/analysis-cache-policy';
 import { useAnalysisStore } from '@/lib/analysis-store';
 import type { Project } from '@/lib/project-store';
 

--- a/app/src/hooks/__tests__/useAnalysis.test.tsx
+++ b/app/src/hooks/__tests__/useAnalysis.test.tsx
@@ -175,11 +175,17 @@ describe('useAnalysis memory cache', () => {
     });
     expect(lineageActions.setResult).toHaveBeenLastCalledWith(null);
     lineageActions.setResult.mockClear();
+    lineageActions.setAnalyzedContent.mockClear();
+    lineageActions.setStalePaths.mockClear();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(300);
     });
     expect(lineageActions.setResult).toHaveBeenCalledWith(cachedResult);
+    expect(lineageActions.setAnalyzedContent).toHaveBeenCalledWith(
+      new Map([['model.sql', projectA.files[0].content]])
+    );
+    expect(lineageActions.setStalePaths).toHaveBeenCalledWith([]);
   });
 
   it('ignores an old persistent lookup that resolves during the debounce window', async () => {

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useMemo, useRef, startTransition } from 'react';
+import type { AnalyzeResult } from '@pondpilot/flowscope-core';
 import { useLineage } from '@pondpilot/flowscope-react';
 import { analyzeWithWorker, getCachedAnalysis, syncAnalysisFiles } from '@/lib/analysis-worker';
 import type { BackendAdapter, AnalysisPayload } from '@/lib/backend-adapter';
@@ -296,6 +297,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     if (!currentAnalysisCacheKey) {
       if (attemptedCacheIdentityRef.current?.projectId !== activeProjectId) {
         actionsRef.current.setResult(null);
+        attemptedCacheIdentityRef.current = { projectId: activeProjectId, cacheKey: null };
       }
       return;
     }
@@ -502,6 +504,21 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         const cachedResult =
           activeProjectId && canUseMemoryCache ? getResult(activeProjectId, cacheKey) : null;
         const knownCacheKey = cachedResult ? cacheKey : null;
+        const displayResult = (result: AnalyzeResult) => {
+          startTransition(() => {
+            actionsRef.current.setResult(result);
+            actionsRef.current.setAnalyzedContent(
+              new Map(context.files.map((file) => [file.name, file.content]))
+            );
+            actionsRef.current.setStalePaths([]);
+          });
+        };
+
+        // A known key asks the worker to omit its result payload, so install the
+        // exact memory hit before allowing that response optimization.
+        if (cachedResult) {
+          displayResult(cachedResult);
+        }
 
         let analysisResponse: Awaited<ReturnType<typeof analyzeWithWorker>>;
         let fileSyncRetries = 0;
@@ -568,18 +585,9 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
             throw new Error('Analysis response cache key did not match the requested inputs');
           }
 
-          // Use startTransition to make the result update low-priority,
-          // allowing UI interactions and worker callbacks to proceed without blocking
-          startTransition(() => {
-            actionsRef.current.setResult(analysisResponse.result);
-            // Snapshot the exact content that was just analyzed so the
-            // staleness gate (#22) has a baseline to diff future edits
-            // against. Keyed by the same path the analyzer keys statements by.
-            actionsRef.current.setAnalyzedContent(
-              new Map(context.files.map((f) => [f.name, f.content]))
-            );
-            actionsRef.current.setStalePaths([]);
-          });
+          // Snapshot the exact content that was just analyzed so the staleness
+          // gate (#22) has a baseline keyed like analyzer statements.
+          displayResult(analysisResponse.result);
           if (activeProjectId && canUseMemoryCache) {
             storeResult(activeProjectId, cacheKey, analysisResponse.result);
           }

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -308,6 +308,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     // allowing UI interactions and worker callbacks to proceed without blocking
     startTransition(() => {
       actionsRef.current.setResult(restoreDecision.result);
+      if (restoreDecision.result && currentAnalysisInput) {
+        actionsRef.current.setAnalyzedContent(
+          new Map(currentAnalysisInput.context.files.map((file) => [file.name, file.content]))
+        );
+        actionsRef.current.setStalePaths([]);
+      }
     });
   }, [
     activeProjectId,
@@ -315,6 +321,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     backendSchemaIdentity,
     canUseMemoryCache,
     currentAnalysisCacheKey,
+    currentAnalysisInput,
     getResult,
   ]);
 

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -4,8 +4,12 @@ import { analyzeWithWorker, getCachedAnalysis, syncAnalysisFiles } from '@/lib/a
 import type { BackendAdapter, AnalysisPayload } from '@/lib/backend-adapter';
 import { useProject } from '@/lib/project-store';
 import type { Project } from '@/lib/project-store';
-import { useAnalysisStore } from '@/lib/analysis-store';
-import { buildAnalysisCacheKey } from '@/lib/analysis-hash';
+import {
+  getAnalysisCacheRestoreDecision,
+  useAnalysisStore,
+  type AnalysisCacheIdentity,
+} from '@/lib/analysis-store';
+import { buildAnalysisCacheKey, canBuildProactiveAnalysisCacheKey } from '@/lib/analysis-hash';
 import { useViewStateStore, getIssuesStateWithDefaults } from '@/lib/view-state-store';
 import { FILE_LIMITS, ANALYSIS_SQL_PREVIEW_LIMITS } from '@/lib/constants';
 import { AnalysisErrorCode, isAnalysisError } from '@/types';
@@ -57,7 +61,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     lastAnalyzedAt: null,
   });
   const analysisRequestRef = useRef(0);
-  const restoredProjectRef = useRef<string | null>(null);
+  const attemptedCacheIdentityRef = useRef<AnalysisCacheIdentity | null>(null);
 
   // Use ref for actions to avoid dependency issues (actions object changes every render)
   const actionsRef = useRef(actions);
@@ -185,7 +189,8 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
 
   const canUseMemoryCache = !adapter || adapter.type === 'wasm';
   // The canonical hash scans every file character. Skip it for REST (which cannot
-  // reuse memory results) and debounce it for interactive WASM project changes.
+  // reuse memory results), debounce it for interactive WASM project changes, and
+  // keep proactive hashing bounded. Explicit analysis runs still build exact keys.
   const currentAnalysisPayload = useMemo(() => {
     if (!canUseMemoryCache || !activeProjectId) {
       return null;
@@ -199,7 +204,11 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
       activeFile?.content,
       activeFile?.path
     );
-    return analysisPayload ? { ...analysisPayload, projectId: activeProjectId } : null;
+    if (!analysisPayload || !canBuildProactiveAnalysisCacheKey(analysisPayload.payload)) {
+      return null;
+    }
+
+    return { ...analysisPayload, projectId: activeProjectId };
   }, [activeProjectId, buildAnalysisPayload, canUseMemoryCache, currentProject]);
   const debouncedAnalysisPayload = useDebounce(
     currentAnalysisPayload,
@@ -279,30 +288,37 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     const memoryCacheStart = nowMs();
 
     if (!activeProjectId || !canUseMemoryCache) {
-      restoredProjectRef.current = activeProjectId;
+      attemptedCacheIdentityRef.current = null;
       actionsRef.current.setResult(null);
       return;
     }
 
     if (!currentAnalysisCacheKey) {
-      actionsRef.current.setResult(null);
+      if (attemptedCacheIdentityRef.current?.projectId !== activeProjectId) {
+        actionsRef.current.setResult(null);
+      }
       return;
     }
-
-    if (restoredProjectRef.current === activeProjectId) {
-      return;
-    }
-    restoredProjectRef.current = activeProjectId;
 
     const cachedResult = getResult(activeProjectId, currentAnalysisCacheKey);
+    const nextIdentity = { projectId: activeProjectId, cacheKey: currentAnalysisCacheKey };
+    const restoreDecision = getAnalysisCacheRestoreDecision(
+      attemptedCacheIdentityRef.current,
+      nextIdentity,
+      cachedResult
+    );
+    attemptedCacheIdentityRef.current = nextIdentity;
     if (ANALYSIS_DEBUG)
       console.log(
         `[useAnalysis] Memory cache ${cachedResult ? 'HIT' : 'MISS'} (${(nowMs() - memoryCacheStart).toFixed(1)}ms)`
       );
+    if (!restoreDecision.shouldSetResult) {
+      return;
+    }
     // Use startTransition to make the result update low-priority,
     // allowing UI interactions and worker callbacks to proceed without blocking
     startTransition(() => {
-      actionsRef.current.setResult(cachedResult);
+      actionsRef.current.setResult(restoreDecision.result);
     });
   }, [
     activeProjectId,

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -10,7 +10,8 @@ import {
   useAnalysisStore,
   type AnalysisCacheIdentity,
 } from '@/lib/analysis-store';
-import { buildAnalysisCacheKey, canBuildProactiveAnalysisCacheKey } from '@/lib/analysis-hash';
+import { buildAnalysisCacheKey } from '@/lib/analysis-hash';
+import { canBuildProactiveAnalysisCacheKey } from '@/lib/analysis-cache-policy';
 import { useViewStateStore, getIssuesStateWithDefaults } from '@/lib/view-state-store';
 import { FILE_LIMITS, ANALYSIS_SQL_PREVIEW_LIMITS } from '@/lib/constants';
 import { AnalysisErrorCode, isAnalysisError } from '@/types';

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -1,10 +1,11 @@
-import { useState, useCallback, useEffect, useRef, startTransition } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, startTransition } from 'react';
 import { useLineage } from '@pondpilot/flowscope-react';
 import { analyzeWithWorker, getCachedAnalysis, syncAnalysisFiles } from '@/lib/analysis-worker';
 import type { BackendAdapter, AnalysisPayload } from '@/lib/backend-adapter';
 import { useProject } from '@/lib/project-store';
 import type { Project } from '@/lib/project-store';
 import { useAnalysisStore } from '@/lib/analysis-store';
+import { buildAnalysisCacheKey } from '@/lib/analysis-hash';
 import { useViewStateStore, getIssuesStateWithDefaults } from '@/lib/view-state-store';
 import { FILE_LIMITS, ANALYSIS_SQL_PREVIEW_LIMITS } from '@/lib/constants';
 import { AnalysisErrorCode, isAnalysisError } from '@/types';
@@ -40,10 +41,10 @@ export interface UseAnalysisOptions {
  */
 export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions) {
   const adapter = options?.adapter;
-  const { currentProject, activeProjectId } = useProject();
+  const { currentProject, activeProjectId, backendSchema } = useProject();
   const { actions, state: lineageState } = useLineage();
   const { hideCTEs } = lineageState;
-  const { getResult, getMetrics, setResult: storeResult, setMetrics } = useAnalysisStore();
+  const { getResult, setResult: storeResult, setMetrics } = useAnalysisStore();
   const getViewState = useViewStateStore((s) => s.getViewState);
   const enableLinting = activeProjectId
     ? getIssuesStateWithDefaults(getViewState(activeProjectId, 'issues')).showLintIssues
@@ -54,11 +55,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     lastAnalyzedAt: null,
   });
   const analysisRequestRef = useRef(0);
-  const currentProjectRef = useRef<Project | null>(currentProject);
-
-  useEffect(() => {
-    currentProjectRef.current = currentProject;
-  }, [currentProject]);
+  const restoredProjectRef = useRef<string | null>(null);
 
   // Use ref for actions to avoid dependency issues (actions object changes every render)
   const actionsRef = useRef(actions);
@@ -144,6 +141,49 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     []
   );
 
+  const buildAnalysisInput = useCallback(
+    (project: Project | null, activeFileContent?: string, activeFilePath?: string) => {
+      const context = buildAnalysisContext(project, activeFileContent, activeFilePath);
+      if (!project || !context) {
+        return null;
+      }
+
+      const payload: AnalysisPayload = {
+        files: context.files,
+        dialect: project.dialect,
+        schemaSQL: project.schemaSQL ?? '',
+        hideCTEs,
+        enableColumnLineage: true,
+        enableLinting,
+        templateMode: project.templateMode,
+      };
+
+      return {
+        context,
+        payload,
+        cacheKey: buildAnalysisCacheKey(payload),
+      };
+    },
+    [buildAnalysisContext, enableLinting, hideCTEs]
+  );
+
+  const currentAnalysisInput = useMemo(() => {
+    const activeFile = currentProject?.files.find(
+      (file) => file.id === currentProject.activeFileId
+    );
+    return buildAnalysisInput(currentProject, activeFile?.content, activeFile?.path);
+  }, [buildAnalysisInput, currentProject]);
+  const currentAnalysisCacheKey = currentAnalysisInput?.cacheKey ?? null;
+  const canUseMemoryCache = !adapter || adapter.type === 'wasm';
+
+  // The REST server owns additional schema/template configuration that is not
+  // fully represented by AnalysisPayload. Never reuse its results in memory;
+  // this identity only clears the displayed result when the visible schema changes.
+  const backendSchemaIdentity = useMemo(
+    () => (adapter?.type === 'rest' ? JSON.stringify(backendSchema) : null),
+    [adapter?.type, backendSchema]
+  );
+
   useEffect(() => {
     if (!backendReady || !currentProject) {
       return;
@@ -181,22 +221,29 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     };
   }, [currentProject, backendReady, adapter]);
 
-  // Restore cached analysis result from memory when project or hideCTEs changes.
-  // Cache validation is built into getResult - it returns null if the cached
-  // result was computed with a different hideCTEs setting.
+  // Restore a result only when switching to a project whose canonical analysis
+  // key matches. Input changes within the active project may keep the current
+  // graph visible for the staleness UI, but that result is never restored or
+  // sent to the worker as a known cache hit under a different key.
   useEffect(() => {
     if (ANALYSIS_DEBUG)
       console.log(
         `[useAnalysis] Memory cache effect triggered (projectId: ${activeProjectId?.slice(0, 8) ?? 'null'})`
       );
     const memoryCacheStart = nowMs();
+    const projectChanged = restoredProjectRef.current !== activeProjectId;
+    restoredProjectRef.current = activeProjectId;
 
-    if (!activeProjectId) {
+    if (!activeProjectId || !currentAnalysisCacheKey || !canUseMemoryCache) {
       actionsRef.current.setResult(null);
       return;
     }
 
-    const cachedResult = getResult(activeProjectId, hideCTEs);
+    if (!projectChanged) {
+      return;
+    }
+
+    const cachedResult = getResult(activeProjectId, currentAnalysisCacheKey);
     if (ANALYSIS_DEBUG)
       console.log(
         `[useAnalysis] Memory cache ${cachedResult ? 'HIT' : 'MISS'} (${(nowMs() - memoryCacheStart).toFixed(1)}ms)`
@@ -206,11 +253,14 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     startTransition(() => {
       actionsRef.current.setResult(cachedResult);
     });
-
-    if (cachedResult || !backendReady) {
-      return;
-    }
-  }, [activeProjectId, hideCTEs, getResult, backendReady]);
+  }, [
+    activeProjectId,
+    backendReady,
+    backendSchemaIdentity,
+    canUseMemoryCache,
+    currentAnalysisCacheKey,
+    getResult,
+  ]);
 
   // Check worker's IndexedDB cache for persisted analysis results.
   // This runs after the memory cache effect and may update the result
@@ -221,24 +271,20 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         `[useAnalysis] IndexedDB cache effect triggered (projectId: ${activeProjectId?.slice(0, 8) ?? 'null'})`
       );
 
-    if (!backendReady || !activeProjectId) {
+    if (!backendReady || !activeProjectId || !currentAnalysisInput) {
       return;
     }
 
-    const cachedResult = getResult(activeProjectId, hideCTEs);
+    const cachedResult = canUseMemoryCache
+      ? getResult(activeProjectId, currentAnalysisInput.cacheKey)
+      : null;
     if (cachedResult) {
       if (ANALYSIS_DEBUG) console.log('[useAnalysis] IndexedDB cache skipped (memory cache hit)');
       return;
     }
 
-    const project = currentProjectRef.current;
-    if (!project) {
-      return;
-    }
-
-    const activeFile = project.files.find((file) => file.id === project.activeFileId);
-    const context = buildAnalysisContext(project, activeFile?.content, activeFile?.path);
-    if (!context || context.files.length === 0) {
+    const { context, payload: cachePayload, cacheKey } = currentAnalysisInput;
+    if (context.files.length === 0) {
       return;
     }
 
@@ -246,16 +292,6 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     const cacheStart = nowMs();
     if (ANALYSIS_DEBUG)
       console.log(`[useAnalysis] Checking IndexedDB cache for ${context.files.length} files`);
-
-    const cachePayload: AnalysisPayload = {
-      files: context.files,
-      dialect: project.dialect,
-      schemaSQL: project.schemaSQL ?? '',
-      hideCTEs,
-      enableColumnLineage: true,
-      enableLinting,
-      templateMode: project.templateMode,
-    };
 
     const syncAndGetCache = adapter
       ? adapter.syncFiles(context.files).then(() => {
@@ -267,12 +303,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
             console.log(`[useAnalysis] Files synced, checking IndexedDB cache...`);
           return getCachedAnalysis({
             fileNames: context.files.map((file) => file.name),
-            dialect: project.dialect,
-            schemaSQL: project.schemaSQL ?? '',
-            hideCTEs,
-            enableColumnLineage: true,
-            enableLinting,
-            templateMode: project.templateMode,
+            dialect: cachePayload.dialect,
+            schemaSQL: cachePayload.schemaSQL,
+            hideCTEs: cachePayload.hideCTEs,
+            enableColumnLineage: cachePayload.enableColumnLineage,
+            enableLinting: cachePayload.enableLinting,
+            templateMode: cachePayload.templateMode,
           });
         });
 
@@ -284,7 +320,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
             console.log(`[useAnalysis] IndexedDB cache cancelled after ${durationMs.toFixed(1)}ms`);
           return;
         }
-        if (!cached?.result) {
+        if (!cached?.result || cached.cacheKey !== cacheKey) {
           if (ANALYSIS_DEBUG)
             console.log(`[useAnalysis] IndexedDB cache MISS after ${durationMs.toFixed(1)}ms`);
           return;
@@ -305,7 +341,9 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
           );
           actionsRef.current.setStalePaths([]);
         });
-        storeResult(activeProjectId, cached.result, hideCTEs);
+        if (canUseMemoryCache) {
+          storeResult(activeProjectId, cacheKey, cached.result);
+        }
         setMetrics(activeProjectId, {
           lastDurationMs: durationMs,
           lastCacheHit: true,
@@ -325,13 +363,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     };
   }, [
     activeProjectId,
-    hideCTEs,
-    enableLinting,
+    canUseMemoryCache,
+    currentAnalysisInput,
     getResult,
     storeResult,
     setMetrics,
     backendReady,
-    buildAnalysisContext,
     adapter,
   ]);
 
@@ -349,12 +386,14 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
       try {
-        const context = buildAnalysisContext(currentProject, activeFileContent, activeFilePath);
+        const analysisInput = buildAnalysisInput(currentProject, activeFileContent, activeFilePath);
 
-        if (!context) {
+        if (!analysisInput) {
           setError('No project context available');
           return;
         }
+
+        const { context, payload: adapterPayload, cacheKey } = analysisInput;
 
         if (context.files.length === 0) {
           if (currentProject.runMode === 'custom') {
@@ -393,21 +432,9 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
           actionsRef.current.setSql(activeFileContent);
         }
 
-        const adapterPayload: AnalysisPayload = {
-          files: context.files,
-          dialect: currentProject.dialect,
-          schemaSQL: currentProject.schemaSQL ?? '',
-          hideCTEs,
-          enableColumnLineage: true,
-          enableLinting,
-          templateMode: currentProject.templateMode,
-        };
-
-        const cachedResult = activeProjectId ? getResult(activeProjectId, hideCTEs) : null;
-        const knownCacheKey =
-          cachedResult && activeProjectId
-            ? (getMetrics(activeProjectId)?.lastCacheKey ?? null)
-            : null;
+        const cachedResult =
+          activeProjectId && canUseMemoryCache ? getResult(activeProjectId, cacheKey) : null;
+        const knownCacheKey = cachedResult ? cacheKey : null;
 
         let analysisResponse: Awaited<ReturnType<typeof analyzeWithWorker>>;
         let fileSyncRetries = 0;
@@ -434,12 +461,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
           // Fallback to direct worker calls for backwards compatibility
           const workerPayload = {
             fileNames: context.files.map((file) => file.name),
-            dialect: currentProject.dialect,
-            schemaSQL: currentProject.schemaSQL ?? '',
-            hideCTEs,
-            enableColumnLineage: true,
-            enableLinting,
-            templateMode: currentProject.templateMode,
+            dialect: adapterPayload.dialect,
+            schemaSQL: adapterPayload.schemaSQL,
+            hideCTEs: adapterPayload.hideCTEs,
+            enableColumnLineage: adapterPayload.enableColumnLineage,
+            enableLinting: adapterPayload.enableLinting,
+            templateMode: adapterPayload.templateMode,
           };
 
           while (true) {
@@ -470,6 +497,10 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         const durationMs = performance.now() - analysisStart;
 
         if (!analysisResponse.skipped && analysisResponse.result) {
+          if (canUseMemoryCache && analysisResponse.cacheKey !== cacheKey) {
+            throw new Error('Analysis response cache key did not match the requested inputs');
+          }
+
           // Use startTransition to make the result update low-priority,
           // allowing UI interactions and worker callbacks to proceed without blocking
           startTransition(() => {
@@ -482,8 +513,8 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
             );
             actionsRef.current.setStalePaths([]);
           });
-          if (activeProjectId) {
-            storeResult(activeProjectId, analysisResponse.result, hideCTEs);
+          if (activeProjectId && canUseMemoryCache) {
+            storeResult(activeProjectId, cacheKey, analysisResponse.result);
           }
         }
 
@@ -515,14 +546,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
       activeProjectId,
       storeResult,
       setMetrics,
-      getMetrics,
       getResult,
-      buildAnalysisContext,
+      buildAnalysisInput,
       validateFiles,
       setAnalyzing,
       setError,
-      hideCTEs,
-      enableLinting,
+      canUseMemoryCache,
       adapter,
     ]
   );

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -10,9 +10,11 @@ import { useViewStateStore, getIssuesStateWithDefaults } from '@/lib/view-state-
 import { FILE_LIMITS, ANALYSIS_SQL_PREVIEW_LIMITS } from '@/lib/constants';
 import { AnalysisErrorCode, isAnalysisError } from '@/types';
 import type { AnalysisState, AnalysisContext, FileValidationResult } from '@/types';
+import { useDebounce } from './useDebounce';
 
 // Maximum retry attempts for file sync errors to prevent infinite loops
 const MAX_FILE_SYNC_RETRIES = 1;
+const ANALYSIS_CACHE_KEY_DEBOUNCE_MS = 300;
 
 // Debug flag for analysis-related logging - only enabled in development
 const ANALYSIS_DEBUG = !!(import.meta as { env?: { DEV?: boolean } }).env?.DEV;
@@ -141,7 +143,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     []
   );
 
-  const buildAnalysisInput = useCallback(
+  const buildAnalysisPayload = useCallback(
     (project: Project | null, activeFileContent?: string, activeFilePath?: string) => {
       const context = buildAnalysisContext(project, activeFileContent, activeFilePath);
       if (!project || !context) {
@@ -161,20 +163,64 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
       return {
         context,
         payload,
-        cacheKey: buildAnalysisCacheKey(payload),
       };
     },
     [buildAnalysisContext, enableLinting, hideCTEs]
   );
 
-  const currentAnalysisInput = useMemo(() => {
+  const buildAnalysisInput = useCallback(
+    (project: Project | null, activeFileContent?: string, activeFilePath?: string) => {
+      const analysisPayload = buildAnalysisPayload(project, activeFileContent, activeFilePath);
+      if (!analysisPayload) {
+        return null;
+      }
+
+      return {
+        ...analysisPayload,
+        cacheKey: buildAnalysisCacheKey(analysisPayload.payload),
+      };
+    },
+    [buildAnalysisPayload]
+  );
+
+  const canUseMemoryCache = !adapter || adapter.type === 'wasm';
+  // The canonical hash scans every file character. Skip it for REST (which cannot
+  // reuse memory results) and debounce it for interactive WASM project changes.
+  const currentAnalysisPayload = useMemo(() => {
+    if (!canUseMemoryCache || !activeProjectId) {
+      return null;
+    }
+
     const activeFile = currentProject?.files.find(
       (file) => file.id === currentProject.activeFileId
     );
-    return buildAnalysisInput(currentProject, activeFile?.content, activeFile?.path);
-  }, [buildAnalysisInput, currentProject]);
+    const analysisPayload = buildAnalysisPayload(
+      currentProject,
+      activeFile?.content,
+      activeFile?.path
+    );
+    return analysisPayload ? { ...analysisPayload, projectId: activeProjectId } : null;
+  }, [activeProjectId, buildAnalysisPayload, canUseMemoryCache, currentProject]);
+  const debouncedAnalysisPayload = useDebounce(
+    currentAnalysisPayload,
+    ANALYSIS_CACHE_KEY_DEBOUNCE_MS
+  );
+  const currentAnalysisInput = useMemo(() => {
+    if (
+      !canUseMemoryCache ||
+      !debouncedAnalysisPayload ||
+      debouncedAnalysisPayload.projectId !== activeProjectId
+    ) {
+      return null;
+    }
+
+    return {
+      context: debouncedAnalysisPayload.context,
+      payload: debouncedAnalysisPayload.payload,
+      cacheKey: buildAnalysisCacheKey(debouncedAnalysisPayload.payload),
+    };
+  }, [activeProjectId, canUseMemoryCache, debouncedAnalysisPayload]);
   const currentAnalysisCacheKey = currentAnalysisInput?.cacheKey ?? null;
-  const canUseMemoryCache = !adapter || adapter.type === 'wasm';
 
   // The REST server owns additional schema/template configuration that is not
   // fully represented by AnalysisPayload. Never reuse its results in memory;
@@ -231,17 +277,22 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         `[useAnalysis] Memory cache effect triggered (projectId: ${activeProjectId?.slice(0, 8) ?? 'null'})`
       );
     const memoryCacheStart = nowMs();
-    const projectChanged = restoredProjectRef.current !== activeProjectId;
-    restoredProjectRef.current = activeProjectId;
 
-    if (!activeProjectId || !currentAnalysisCacheKey || !canUseMemoryCache) {
+    if (!activeProjectId || !canUseMemoryCache) {
+      restoredProjectRef.current = activeProjectId;
       actionsRef.current.setResult(null);
       return;
     }
 
-    if (!projectChanged) {
+    if (!currentAnalysisCacheKey) {
+      actionsRef.current.setResult(null);
       return;
     }
+
+    if (restoredProjectRef.current === activeProjectId) {
+      return;
+    }
+    restoredProjectRef.current = activeProjectId;
 
     const cachedResult = getResult(activeProjectId, currentAnalysisCacheKey);
     if (ANALYSIS_DEBUG)

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -173,21 +173,6 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     [buildAnalysisContext, enableLinting, hideCTEs]
   );
 
-  const buildAnalysisInput = useCallback(
-    (project: Project | null, activeFileContent?: string, activeFilePath?: string) => {
-      const analysisPayload = buildAnalysisPayload(project, activeFileContent, activeFilePath);
-      if (!analysisPayload) {
-        return null;
-      }
-
-      return {
-        ...analysisPayload,
-        cacheKey: buildAnalysisCacheKey(analysisPayload.payload),
-      };
-    },
-    [buildAnalysisPayload]
-  );
-
   const canUseMemoryCache = !adapter || adapter.type === 'wasm';
   // The canonical hash scans every file character. Skip it for REST (which cannot
   // reuse memory results), debounce it for interactive WASM project changes, and
@@ -215,6 +200,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     currentAnalysisPayload,
     ANALYSIS_CACHE_KEY_DEBOUNCE_MS
   );
+  const proactiveCacheInputIsSettled = currentAnalysisPayload === debouncedAnalysisPayload;
   const currentAnalysisInput = useMemo(() => {
     if (
       !canUseMemoryCache ||
@@ -340,7 +326,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         `[useAnalysis] IndexedDB cache effect triggered (projectId: ${activeProjectId?.slice(0, 8) ?? 'null'})`
       );
 
-    if (!backendReady || !activeProjectId || !currentAnalysisInput) {
+    if (
+      !backendReady ||
+      !activeProjectId ||
+      !currentAnalysisInput ||
+      !proactiveCacheInputIsSettled
+    ) {
       return;
     }
 
@@ -434,6 +425,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     activeProjectId,
     canUseMemoryCache,
     currentAnalysisInput,
+    proactiveCacheInputIsSettled,
     getResult,
     storeResult,
     setMetrics,
@@ -455,14 +447,18 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
       await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
       try {
-        const analysisInput = buildAnalysisInput(currentProject, activeFileContent, activeFilePath);
+        const analysisInput = buildAnalysisPayload(
+          currentProject,
+          activeFileContent,
+          activeFilePath
+        );
 
         if (!analysisInput) {
           setError('No project context available');
           return;
         }
 
-        const { context, payload: adapterPayload, cacheKey } = analysisInput;
+        const { context, payload: adapterPayload } = analysisInput;
 
         if (context.files.length === 0) {
           if (currentProject.runMode === 'custom') {
@@ -481,6 +477,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
           setError(validation.error || 'Validation failed');
           return;
         }
+        const cacheKey = canUseMemoryCache ? buildAnalysisCacheKey(adapterPayload) : null;
 
         console.log(context.description);
 
@@ -502,7 +499,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         }
 
         const cachedResult =
-          activeProjectId && canUseMemoryCache ? getResult(activeProjectId, cacheKey) : null;
+          activeProjectId && cacheKey ? getResult(activeProjectId, cacheKey) : null;
         const knownCacheKey = cachedResult ? cacheKey : null;
         const displayResult = (result: AnalyzeResult) => {
           startTransition(() => {
@@ -581,14 +578,14 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         const durationMs = performance.now() - analysisStart;
 
         if (!analysisResponse.skipped && analysisResponse.result) {
-          if (canUseMemoryCache && analysisResponse.cacheKey !== cacheKey) {
+          if (cacheKey && analysisResponse.cacheKey !== cacheKey) {
             throw new Error('Analysis response cache key did not match the requested inputs');
           }
 
           // Snapshot the exact content that was just analyzed so the staleness
           // gate (#22) has a baseline keyed like analyzer statements.
           displayResult(analysisResponse.result);
-          if (activeProjectId && canUseMemoryCache) {
+          if (activeProjectId && cacheKey) {
             storeResult(activeProjectId, cacheKey, analysisResponse.result);
           }
         }
@@ -622,7 +619,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
       storeResult,
       setMetrics,
       getResult,
-      buildAnalysisInput,
+      buildAnalysisPayload,
       validateFiles,
       setAnalyzing,
       setError,

--- a/app/src/lib/__tests__/analysis-store.test.ts
+++ b/app/src/lib/__tests__/analysis-store.test.ts
@@ -1,11 +1,7 @@
 import type { AnalyzeResult } from '@pondpilot/flowscope-core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ANALYSIS_MEMORY_CACHE_MAX_ENTRIES, useAnalysisStore } from '@/lib/analysis-store';
-import {
-  buildAnalysisCacheKey,
-  buildFileSyncKey,
-  type AnalysisHashInput,
-} from '@/lib/analysis-hash';
+import { buildAnalysisCacheKey, type AnalysisHashInput } from '@/lib/analysis-hash';
 
 const result = { nodes: [], edges: [], statements: [], issues: [] } as unknown as AnalyzeResult;
 
@@ -52,9 +48,6 @@ describe('analysis memory cache', () => {
     expect(
       useAnalysisStore.getState().getResult('project-1', buildAnalysisCacheKey(changedSelection))
     ).toBeNull();
-
-    // Same-length edits must also reach the worker before its canonical key is built.
-    expect(buildFileSyncKey(baseInput)).not.toBe(buildFileSyncKey(changedContent));
   });
 
   it.each([

--- a/app/src/lib/__tests__/analysis-store.test.ts
+++ b/app/src/lib/__tests__/analysis-store.test.ts
@@ -96,6 +96,7 @@ describe('analysis memory cache', () => {
     const keyA = { projectId: 'project-1', cacheKey: 'key-a' };
     const keyB = { projectId: 'project-1', cacheKey: 'key-b' };
     const otherProject = { projectId: 'project-2', cacheKey: 'key-x' };
+    const clearedProject = { projectId: 'project-1', cacheKey: null };
 
     expect(getAnalysisCacheRestoreDecision(otherProject, keyB, null)).toEqual({
       shouldSetResult: true,
@@ -108,6 +109,14 @@ describe('analysis memory cache', () => {
     expect(getAnalysisCacheRestoreDecision(keyA, keyB, null)).toEqual({
       shouldSetResult: false,
       result: null,
+    });
+    expect(getAnalysisCacheRestoreDecision(clearedProject, keyB, null)).toEqual({
+      shouldSetResult: false,
+      result: null,
+    });
+    expect(getAnalysisCacheRestoreDecision(clearedProject, keyA, result)).toEqual({
+      shouldSetResult: true,
+      result,
     });
   });
 

--- a/app/src/lib/__tests__/analysis-store.test.ts
+++ b/app/src/lib/__tests__/analysis-store.test.ts
@@ -1,0 +1,92 @@
+import type { AnalyzeResult } from '@pondpilot/flowscope-core';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ANALYSIS_MEMORY_CACHE_MAX_ENTRIES, useAnalysisStore } from '@/lib/analysis-store';
+import {
+  buildAnalysisCacheKey,
+  buildFileSyncKey,
+  type AnalysisHashInput,
+} from '@/lib/analysis-hash';
+
+const result = { nodes: [], edges: [], statements: [], issues: [] } as unknown as AnalyzeResult;
+
+const baseInput: AnalysisHashInput = {
+  files: [{ name: 'model.sql', content: 'SELECT 1' }],
+  dialect: 'generic',
+  schemaSQL: '',
+  hideCTEs: false,
+  enableColumnLineage: true,
+  enableLinting: false,
+  templateMode: 'raw',
+};
+
+describe('analysis memory cache', () => {
+  beforeEach(() => {
+    useAnalysisStore.getState().clearAllResults();
+  });
+
+  it('reuses a result only for the exact canonical analysis key', () => {
+    const cacheKey = buildAnalysisCacheKey(baseInput);
+
+    useAnalysisStore.getState().setResult('project-1', cacheKey, result);
+
+    expect(useAnalysisStore.getState().getResult('project-1', cacheKey)).toBe(result);
+    expect(useAnalysisStore.getState().getResult('project-2', cacheKey)).toBeNull();
+  });
+
+  it('misses after SQL content or selected files change', () => {
+    const originalKey = buildAnalysisCacheKey(baseInput);
+    useAnalysisStore.getState().setResult('project-1', originalKey, result);
+
+    const changedContent = {
+      ...baseInput,
+      files: [{ name: 'model.sql', content: 'SELECT 2' }],
+    };
+    const changedSelection = {
+      ...baseInput,
+      files: [...baseInput.files, { name: 'other.sql', content: 'SELECT 2' }],
+    };
+
+    expect(
+      useAnalysisStore.getState().getResult('project-1', buildAnalysisCacheKey(changedContent))
+    ).toBeNull();
+    expect(
+      useAnalysisStore.getState().getResult('project-1', buildAnalysisCacheKey(changedSelection))
+    ).toBeNull();
+
+    // Same-length edits must also reach the worker before its canonical key is built.
+    expect(buildFileSyncKey(baseInput)).not.toBe(buildFileSyncKey(changedContent));
+  });
+
+  it.each([
+    ['dialect', { ...baseInput, dialect: 'postgres' as const }],
+    ['schema', { ...baseInput, schemaSQL: 'CREATE TABLE source (id INT);' }],
+    ['template configuration', { ...baseInput, templateMode: 'dbt' as const }],
+    ['lint configuration', { ...baseInput, enableLinting: true }],
+  ])('misses after %s changes', (_name, changedInput) => {
+    const originalKey = buildAnalysisCacheKey(baseInput);
+    useAnalysisStore.getState().setResult('project-1', originalKey, result);
+
+    expect(
+      useAnalysisStore.getState().getResult('project-1', buildAnalysisCacheKey(changedInput))
+    ).toBeNull();
+  });
+
+  it('evicts the oldest project result when the cache reaches its bound', () => {
+    for (let index = 0; index <= ANALYSIS_MEMORY_CACHE_MAX_ENTRIES; index += 1) {
+      useAnalysisStore.getState().setResult(`project-${index}`, `cache-${index}`, result);
+    }
+
+    expect(Object.keys(useAnalysisStore.getState().results)).toHaveLength(
+      ANALYSIS_MEMORY_CACHE_MAX_ENTRIES
+    );
+    expect(useAnalysisStore.getState().getResult('project-0', 'cache-0')).toBeNull();
+    expect(
+      useAnalysisStore
+        .getState()
+        .getResult(
+          `project-${ANALYSIS_MEMORY_CACHE_MAX_ENTRIES}`,
+          `cache-${ANALYSIS_MEMORY_CACHE_MAX_ENTRIES}`
+        )
+    ).toBe(result);
+  });
+});

--- a/app/src/lib/__tests__/analysis-store.test.ts
+++ b/app/src/lib/__tests__/analysis-store.test.ts
@@ -1,7 +1,16 @@
 import type { AnalyzeResult } from '@pondpilot/flowscope-core';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { ANALYSIS_MEMORY_CACHE_MAX_ENTRIES, useAnalysisStore } from '@/lib/analysis-store';
-import { buildAnalysisCacheKey, type AnalysisHashInput } from '@/lib/analysis-hash';
+import {
+  ANALYSIS_MEMORY_CACHE_MAX_ENTRIES,
+  getAnalysisCacheRestoreDecision,
+  useAnalysisStore,
+} from '@/lib/analysis-store';
+import {
+  PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS,
+  buildAnalysisCacheKey,
+  canBuildProactiveAnalysisCacheKey,
+  type AnalysisHashInput,
+} from '@/lib/analysis-hash';
 
 const result = { nodes: [], edges: [], statements: [], issues: [] } as unknown as AnalyzeResult;
 
@@ -81,5 +90,40 @@ describe('analysis memory cache', () => {
           `cache-${ANALYSIS_MEMORY_CACHE_MAX_ENTRIES}`
         )
     ).toBe(result);
+  });
+
+  it('restores an exact hit after a project-level miss without clearing same-project misses', () => {
+    const keyA = { projectId: 'project-1', cacheKey: 'key-a' };
+    const keyB = { projectId: 'project-1', cacheKey: 'key-b' };
+    const otherProject = { projectId: 'project-2', cacheKey: 'key-x' };
+
+    expect(getAnalysisCacheRestoreDecision(otherProject, keyB, null)).toEqual({
+      shouldSetResult: true,
+      result: null,
+    });
+    expect(getAnalysisCacheRestoreDecision(keyB, keyA, result)).toEqual({
+      shouldSetResult: true,
+      result,
+    });
+    expect(getAnalysisCacheRestoreDecision(keyA, keyB, null)).toEqual({
+      shouldSetResult: false,
+      result: null,
+    });
+  });
+
+  it('bounds proactive key hashing without changing canonical run-time keys', () => {
+    const overLimit = {
+      ...baseInput,
+      files: [
+        {
+          name: '',
+          content: 'x'.repeat(PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS + 1),
+        },
+      ],
+    };
+
+    expect(canBuildProactiveAnalysisCacheKey(baseInput)).toBe(true);
+    expect(canBuildProactiveAnalysisCacheKey(overLimit)).toBe(false);
+    expect(buildAnalysisCacheKey(overLimit)).not.toBe(buildAnalysisCacheKey(baseInput));
   });
 });

--- a/app/src/lib/__tests__/analysis-store.test.ts
+++ b/app/src/lib/__tests__/analysis-store.test.ts
@@ -7,10 +7,9 @@ import {
 } from '@/lib/analysis-store';
 import {
   PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS,
-  buildAnalysisCacheKey,
   canBuildProactiveAnalysisCacheKey,
-  type AnalysisHashInput,
-} from '@/lib/analysis-hash';
+} from '@/lib/analysis-cache-policy';
+import { buildAnalysisCacheKey, type AnalysisHashInput } from '@/lib/analysis-hash';
 
 const result = { nodes: [], edges: [], statements: [], issues: [] } as unknown as AnalyzeResult;
 

--- a/app/src/lib/analysis-cache-policy.ts
+++ b/app/src/lib/analysis-cache-policy.ts
@@ -1,0 +1,33 @@
+import type { AnalysisHashInput } from './analysis-hash';
+
+/**
+ * Proactive cache restoration runs on the UI thread after edits settle. Keep
+ * that opportunistic work below a small payload size; explicit analysis runs
+ * always build the exact canonical key regardless of size.
+ */
+export const PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS = 250_000;
+
+// Current canonical keys hash a two-character version and three boolean flags
+// in addition to the variable semantic fields counted below.
+const CANONICAL_CACHE_KEY_FIXED_CHARS = 5;
+
+export function canBuildProactiveAnalysisCacheKey(input: AnalysisHashInput): boolean {
+  let totalChars =
+    CANONICAL_CACHE_KEY_FIXED_CHARS +
+    input.dialect.length +
+    input.schemaSQL.length +
+    (input.templateMode ?? 'raw').length;
+
+  if (totalChars > PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS) {
+    return false;
+  }
+
+  for (const file of input.files) {
+    totalChars += file.name.length + file.content.length;
+    if (totalChars > PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/app/src/lib/analysis-hash.ts
+++ b/app/src/lib/analysis-hash.ts
@@ -85,7 +85,7 @@ export function buildFileSyncKey(input: FileSyncInput): string {
   for (const file of input.files) {
     // Variable-length fields use length-prefixed hashing
     hash = updateHashWithField(hash, file.name);
-    hash = updateHashWithField(hash, file.content);
+    hash = updateHashWithString(hash, String(file.content.length));
   }
 
   return hash.toString(16).padStart(16, '0');

--- a/app/src/lib/analysis-hash.ts
+++ b/app/src/lib/analysis-hash.ts
@@ -13,13 +13,6 @@ const FNV_OFFSET_BASIS = 0xcbf29ce484222325n;
 const FNV_PRIME = 0x100000001b3n;
 const FNV_MASK = 0xffffffffffffffffn;
 
-/**
- * Proactive cache restoration runs on the UI thread after edits settle. Keep
- * that opportunistic work below a small payload size; explicit analysis runs
- * always build the exact canonical key regardless of size.
- */
-export const PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS = 250_000;
-
 export interface AnalysisHashInput {
   files: Array<{ name: string; content: string }>;
   dialect: Dialect;
@@ -32,28 +25,6 @@ export interface AnalysisHashInput {
 
 export interface FileSyncInput {
   files: Array<{ name: string; content: string }>;
-}
-
-export function canBuildProactiveAnalysisCacheKey(input: AnalysisHashInput): boolean {
-  let totalChars =
-    HASH_VERSION.length +
-    input.dialect.length +
-    input.schemaSQL.length +
-    (input.templateMode ?? 'raw').length +
-    3;
-
-  if (totalChars > PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS) {
-    return false;
-  }
-
-  for (const file of input.files) {
-    totalChars += file.name.length + file.content.length;
-    if (totalChars > PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
 /**

--- a/app/src/lib/analysis-hash.ts
+++ b/app/src/lib/analysis-hash.ts
@@ -13,6 +13,13 @@ const FNV_OFFSET_BASIS = 0xcbf29ce484222325n;
 const FNV_PRIME = 0x100000001b3n;
 const FNV_MASK = 0xffffffffffffffffn;
 
+/**
+ * Proactive cache restoration runs on the UI thread after edits settle. Keep
+ * that opportunistic work below a small payload size; explicit analysis runs
+ * always build the exact canonical key regardless of size.
+ */
+export const PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS = 250_000;
+
 export interface AnalysisHashInput {
   files: Array<{ name: string; content: string }>;
   dialect: Dialect;
@@ -25,6 +32,28 @@ export interface AnalysisHashInput {
 
 export interface FileSyncInput {
   files: Array<{ name: string; content: string }>;
+}
+
+export function canBuildProactiveAnalysisCacheKey(input: AnalysisHashInput): boolean {
+  let totalChars =
+    HASH_VERSION.length +
+    input.dialect.length +
+    input.schemaSQL.length +
+    (input.templateMode ?? 'raw').length +
+    3;
+
+  if (totalChars > PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS) {
+    return false;
+  }
+
+  for (const file of input.files) {
+    totalChars += file.name.length + file.content.length;
+    if (totalChars > PROACTIVE_ANALYSIS_CACHE_KEY_MAX_CHARS) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**

--- a/app/src/lib/analysis-hash.ts
+++ b/app/src/lib/analysis-hash.ts
@@ -85,7 +85,7 @@ export function buildFileSyncKey(input: FileSyncInput): string {
   for (const file of input.files) {
     // Variable-length fields use length-prefixed hashing
     hash = updateHashWithField(hash, file.name);
-    hash = updateHashWithString(hash, String(file.content.length));
+    hash = updateHashWithField(hash, file.content);
   }
 
   return hash.toString(16).padStart(16, '0');

--- a/app/src/lib/analysis-store.ts
+++ b/app/src/lib/analysis-store.ts
@@ -26,7 +26,7 @@ let cacheSequence = 0;
 
 export interface AnalysisCacheIdentity {
   projectId: string;
-  cacheKey: string;
+  cacheKey: string | null;
 }
 
 export interface AnalysisCacheRestoreDecision {

--- a/app/src/lib/analysis-store.ts
+++ b/app/src/lib/analysis-store.ts
@@ -24,6 +24,35 @@ export const ANALYSIS_MEMORY_CACHE_MAX_ENTRIES = 10;
 
 let cacheSequence = 0;
 
+export interface AnalysisCacheIdentity {
+  projectId: string;
+  cacheKey: string;
+}
+
+export interface AnalysisCacheRestoreDecision {
+  shouldSetResult: boolean;
+  result: AnalyzeResult | null;
+}
+
+/**
+ * Project switches replace the visible graph even on a miss. Within one
+ * project, exact hits replace it while misses preserve the stale graph.
+ */
+export function getAnalysisCacheRestoreDecision(
+  previous: AnalysisCacheIdentity | null,
+  next: AnalysisCacheIdentity,
+  cachedResult: AnalyzeResult | null
+): AnalysisCacheRestoreDecision {
+  if (previous?.projectId === next.projectId && previous.cacheKey === next.cacheKey) {
+    return { shouldSetResult: false, result: cachedResult };
+  }
+
+  return {
+    shouldSetResult: previous?.projectId !== next.projectId || cachedResult !== null,
+    result: cachedResult,
+  };
+}
+
 export interface AnalysisWorkerTimings {
   totalMs: number;
   cacheReadMs: number;

--- a/app/src/lib/analysis-store.ts
+++ b/app/src/lib/analysis-store.ts
@@ -5,8 +5,9 @@
  * Results are NOT persisted to localStorage due to size constraints.
  * When the user switches projects, we restore their cached result if available.
  *
- * Each cached result tracks the hideCTEs setting used during analysis,
- * allowing cache validation when options change.
+ * Each project keeps only its latest result, tagged with the canonical analysis
+ * cache key. A lookup with any other key is a cache miss, so callers cannot
+ * restore a result produced from different semantic inputs.
  */
 
 import { create } from 'zustand';
@@ -14,9 +15,14 @@ import type { AnalyzeResult } from '@pondpilot/flowscope-core';
 
 interface CachedResult {
   result: AnalyzeResult;
-  /** The hideCTEs value used when this result was computed */
-  hideCTEs: boolean;
+  cacheKey: string;
+  storedAt: number;
 }
+
+/** Large analysis graphs stay bounded even when many projects are opened. */
+export const ANALYSIS_MEMORY_CACHE_MAX_ENTRIES = 10;
+
+let cacheSequence = 0;
 
 export interface AnalysisWorkerTimings {
   totalMs: number;
@@ -34,18 +40,18 @@ export interface AnalysisMetrics {
 }
 
 interface AnalysisStore {
-  /** Analysis results keyed by project ID, with metadata for cache validation */
+  /** Latest analysis result per project, bounded by ANALYSIS_MEMORY_CACHE_MAX_ENTRIES */
   results: Record<string, CachedResult>;
   /** Performance metrics keyed by project ID */
   metrics: Record<string, AnalysisMetrics>;
 
-  /** Get analysis result for a project if cache is valid for given hideCTEs */
-  getResult: (projectId: string, hideCTEs: boolean) => AnalyzeResult | null;
+  /** Get a result only when its canonical analysis cache key matches exactly */
+  getResult: (projectId: string, cacheKey: string) => AnalyzeResult | null;
   /** Get performance metrics for a project */
   getMetrics: (projectId: string) => AnalysisMetrics | null;
 
-  /** Set analysis result for a project with its hideCTEs context */
-  setResult: (projectId: string, result: AnalyzeResult, hideCTEs: boolean) => void;
+  /** Replace a project's cached result and evict the oldest project if needed */
+  setResult: (projectId: string, cacheKey: string, result: AnalyzeResult) => void;
   /** Set performance metrics for a project */
   setMetrics: (projectId: string, metrics: AnalysisMetrics) => void;
 
@@ -60,10 +66,9 @@ export const useAnalysisStore = create<AnalysisStore>((set, get) => ({
   results: {},
   metrics: {},
 
-  getResult: (projectId, hideCTEs) => {
+  getResult: (projectId, cacheKey) => {
     const cached = get().results[projectId];
-    // Return cached result only if it was computed with the same hideCTEs setting
-    if (cached && cached.hideCTEs === hideCTEs) {
+    if (cached?.cacheKey === cacheKey) {
       return cached.result;
     }
     return null;
@@ -71,13 +76,28 @@ export const useAnalysisStore = create<AnalysisStore>((set, get) => ({
 
   getMetrics: (projectId) => get().metrics[projectId] ?? null,
 
-  setResult: (projectId, result, hideCTEs) =>
-    set((state) => ({
-      results: {
+  setResult: (projectId, cacheKey, result) =>
+    set((state) => {
+      const results = {
         ...state.results,
-        [projectId]: { result, hideCTEs },
-      },
-    })),
+        [projectId]: { result, cacheKey, storedAt: (cacheSequence += 1) },
+      };
+      const projectIds = Object.keys(results);
+
+      if (projectIds.length <= ANALYSIS_MEMORY_CACHE_MAX_ENTRIES) {
+        return { results };
+      }
+
+      const oldestProjectId = projectIds.reduce((oldest, candidate) =>
+        results[candidate].storedAt < results[oldest].storedAt ? candidate : oldest
+      );
+      const { [oldestProjectId]: _evictedResult, ...boundedResults } = results;
+      const { [oldestProjectId]: _evictedMetrics, ...boundedMetrics } = state.metrics;
+      void _evictedResult;
+      void _evictedMetrics;
+
+      return { results: boundedResults, metrics: boundedMetrics };
+    }),
 
   setMetrics: (projectId, metrics) =>
     set((state) => ({


### PR DESCRIPTION
## Summary

- key in-memory project results with the existing canonical analysis cache key so every analysis-affecting input must match
- restore exact project/key hits while preserving same-project stale graphs on misses, and ignore persistent lookups as soon as semantic inputs change
- bound the cache to 10 project results and bound proactive UI-thread hashing to 250,000 payload characters after a 300 ms debounce
- keep explicit WASM run keys exact, restore memory hits before worker skip responses, and avoid client cache hashing/reuse for REST analysis

## Root cause

The in-memory store keyed results by project ID and validated only `hideCTEs`. `useAnalysis` could therefore restore a result produced from different SQL, selected files, dialect, schema, template, lint, or other semantic inputs.

## Validation

- `yarn workspace @pondpilot/flowscope-app test analysis-store.test.ts useAnalysis.test.tsx` — 13 passed
- `yarn workspace @pondpilot/flowscope-app test` — 341 passed
- `yarn workspace @pondpilot/flowscope-app typecheck`
- `yarn workspace @pondpilot/flowscope-app lint`
- Prettier check on all changed files
- Codex branch review against `origin/master` — no accepted/actionable findings