### PR TITLE
fix(dialects): accept Oracle in TypeScript clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### TypeScript API, Web App, and VS Code Extension
+
+- **Oracle dialect validation** — accepted `oracle` requests in the TypeScript runtime and synchronized Oracle across the app, VS Code settings, and supported-dialect documentation
+
 ## [0.8.0] - 2026-08-11
 
 ### Added

--- a/app/src/lib/project-store.tsx
+++ b/app/src/lib/project-store.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react';
-import type { FileSource, SchemaMetadata } from '@pondpilot/flowscope-core';
+import { VALID_DIALECTS as CORE_VALID_DIALECTS } from '@pondpilot/flowscope-core';
+import type { Dialect as CoreDialect, FileSource, SchemaMetadata } from '@pondpilot/flowscope-core';
 import { STORAGE_KEYS, FILE_EXTENSIONS, SHARE_LIMITS, DEFAULT_FILE_LANGUAGE } from './constants';
 import type { SharePayload } from './share';
 import { parseTemplateMode } from '@/types';
@@ -32,21 +33,7 @@ function validateProjectName(name: string, existingNames: string[]): string | nu
   return trimmed;
 }
 
-export type Dialect =
-  | 'generic'
-  | 'ansi'
-  | 'bigquery'
-  | 'clickhouse'
-  | 'databricks'
-  | 'duckdb'
-  | 'hive'
-  | 'mssql'
-  | 'mysql'
-  | 'oracle'
-  | 'postgres'
-  | 'redshift'
-  | 'snowflake'
-  | 'sqlite';
+export type Dialect = CoreDialect;
 
 /** Human-readable labels for each dialect. */
 const DIALECT_LABELS: Record<Dialect, string> = {
@@ -67,22 +54,7 @@ const DIALECT_LABELS: Record<Dialect, string> = {
 };
 
 /** All valid dialect values for runtime validation. */
-export const VALID_DIALECTS: readonly Dialect[] = [
-  'generic',
-  'ansi',
-  'bigquery',
-  'clickhouse',
-  'databricks',
-  'duckdb',
-  'hive',
-  'mssql',
-  'mysql',
-  'oracle',
-  'postgres',
-  'redshift',
-  'snowflake',
-  'sqlite',
-] as const;
+export const VALID_DIALECTS: readonly Dialect[] = CORE_VALID_DIALECTS;
 
 /**
  * Dialect options for UI dropdowns, derived from VALID_DIALECTS.

--- a/crates/flowscope-cli/README.md
+++ b/crates/flowscope-cli/README.md
@@ -54,7 +54,7 @@ Arguments:
 
 Options:
   -d, --dialect <DIALECT>  SQL dialect [default: generic]
-                           [possible values: generic, ansi, bigquery, clickhouse, databricks, duckdb, hive, mssql, mysql, postgres, redshift, snowflake, sqlite]
+                           [possible values: generic, ansi, bigquery, clickhouse, databricks, duckdb, hive, mssql, mysql, oracle, postgres, redshift, snowflake, sqlite]
   -f, --format <FORMAT>    Output format [default: table]
                            [possible values: table, json, mermaid, html, sql, csv, xlsx, duckdb]
   -s, --schema <FILE>      Schema DDL file for table/column resolution

--- a/crates/flowscope-core/README.md
+++ b/crates/flowscope-core/README.md
@@ -8,7 +8,7 @@ Core SQL lineage analysis engine for FlowScope.
 
 ## Features
 
-- **Multi-Dialect Parsing:** Built on `sqlparser-rs`, supporting PostgreSQL, Snowflake, BigQuery, DuckDB, Redshift, MySQL, SQLite, Databricks, ClickHouse, and Generic ANSI SQL.
+- **Multi-Dialect Parsing:** Built on `sqlparser-rs`, supporting PostgreSQL, Snowflake, BigQuery, DuckDB, Redshift, MySQL, SQLite, Oracle, Databricks, ClickHouse, and Generic ANSI SQL.
 - **Deep Lineage Extraction:**
   - Table-level dependencies (SELECT, INSERT, UPDATE, MERGE, COPY, UNLOAD, etc.)
   - Column-level data flow (including transformations)

--- a/docs/dialect-coverage.md
+++ b/docs/dialect-coverage.md
@@ -15,6 +15,7 @@ These are the dialects exposed by the TypeScript API (`packages/core/src/types.t
 - `hive`
 - `mssql`
 - `mysql`
+- `oracle`
 - `postgres`
 - `redshift`
 - `snowflake`

--- a/docs/dialect-gaps.md
+++ b/docs/dialect-gaps.md
@@ -15,6 +15,7 @@ Some dialects supported by SQLLineage (via SQLFluff) are not yet available.
 | Hive | Yes | Yes | |
 | MS SQL (T-SQL) | Yes | Yes | |
 | MySQL | Yes | Yes | |
+| Oracle | Yes | Yes | |
 | PostgreSQL | Yes | Yes | |
 | Redshift | Yes | Yes | |
 | Snowflake | Yes | Yes | |
@@ -26,7 +27,6 @@ These dialects are supported by SQLLineage (via SQLFluff) but not available in F
 
 | Dialect | Blocking Issue | Workaround |
 |---------|----------------|------------|
-| Oracle | Not in sqlparser-rs | Use Generic dialect |
 | Spark SQL | Not in sqlparser-rs | Use Hive or Databricks dialect |
 | Athena | Not in sqlparser-rs | Use Generic dialect |
 | Vertica | Not in sqlparser-rs | Use Generic dialect |
@@ -47,7 +47,7 @@ These dialects are supported by SQLLineage (via SQLFluff) but not available in F
 
 When using an unsupported dialect, select the closest compatible dialect:
 
-1. **Oracle, DB2, Teradata, Vertica, Exasol** - Use `Generic` dialect
+1. **DB2, Teradata, Vertica, Exasol** - Use `Generic` dialect
 2. **Spark SQL** - Use `Hive` or `Databricks` dialect (Databricks is Spark-based)
 3. **Athena** - Use `Generic` dialect (Athena is Presto/Trino-based)
 4. **Trino** - Use `Generic` dialect
@@ -78,5 +78,4 @@ To request a new dialect in sqlparser-rs:
 
 ### Open Upstream Issues
 
-- Oracle: No active issue (complex PL/SQL support needed)
 - Spark SQL: No dedicated dialect (use Hive or Databricks as workaround)

--- a/docs/dialect_compliance_spec.md
+++ b/docs/dialect_compliance_spec.md
@@ -15,6 +15,7 @@ FlowScope currently exposes these dialects through its public API:
 - `hive`
 - `mssql`
 - `mysql`
+- `oracle`
 - `postgres`
 - `redshift`
 - `snowflake`

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -73,4 +73,4 @@ const result = await analyzeSql({
 ## Supported Dialects
 
 - `generic`, `ansi`, `bigquery`, `clickhouse`, `databricks`, `duckdb`, `hive`
-- `mssql`, `mysql`, `postgres`, `redshift`, `snowflake`, `sqlite`
+- `mssql`, `mysql`, `oracle`, `postgres`, `redshift`, `snowflake`, `sqlite`

--- a/packages/core/src/analyzer.ts
+++ b/packages/core/src/analyzer.ts
@@ -1,4 +1,5 @@
 import { initWasm, isWasmInitialized } from './wasm-loader';
+import { VALID_DIALECTS } from './types';
 import type {
   AnalyzeRequest,
   AnalyzeResult,
@@ -39,23 +40,6 @@ const MAX_SCHEMA_NAME_LENGTH = 63;
  * this roughly corresponds to 10MB. The WASM layer enforces the actual 10MB byte limit.
  */
 const MAX_SQL_LENGTH = 10 * 1024 * 1024;
-
-/** Valid SQL dialects. */
-const VALID_DIALECTS: readonly Dialect[] = [
-  'generic',
-  'ansi',
-  'bigquery',
-  'clickhouse',
-  'databricks',
-  'duckdb',
-  'hive',
-  'mssql',
-  'mysql',
-  'postgres',
-  'redshift',
-  'snowflake',
-  'sqlite',
-] as const;
 
 /**
  * Validate that a dialect value is valid.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,7 @@ export type {
 
 // Constants and utilities
 export {
+  VALID_DIALECTS,
   IssueCodes,
   isTableLikeType,
   charOffsetToByteOffset,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,22 +5,26 @@
 
 // Request Types
 
+/** SQL dialects supported for parsing and analysis. */
+export const VALID_DIALECTS = [
+  'generic',
+  'ansi',
+  'bigquery',
+  'clickhouse',
+  'databricks',
+  'duckdb',
+  'hive',
+  'mssql',
+  'mysql',
+  'oracle',
+  'postgres',
+  'redshift',
+  'snowflake',
+  'sqlite',
+] as const;
+
 /** SQL dialect for parsing and analysis. */
-export type Dialect =
-  | 'generic'
-  | 'ansi'
-  | 'bigquery'
-  | 'clickhouse'
-  | 'databricks'
-  | 'duckdb'
-  | 'hive'
-  | 'mssql'
-  | 'mysql'
-  | 'oracle'
-  | 'postgres'
-  | 'redshift'
-  | 'snowflake'
-  | 'sqlite';
+export type Dialect = (typeof VALID_DIALECTS)[number];
 
 /** Case sensitivity mode for identifier normalization. */
 export type CaseSensitivity = 'dialect' | 'lower' | 'upper' | 'exact';

--- a/packages/core/tests/analyzer.test.ts
+++ b/packages/core/tests/analyzer.test.ts
@@ -74,11 +74,23 @@ describe('analyzer', () => {
     );
   });
 
-  it('validates dialect values', async () => {
+  it('rejects invalid dialect values', async () => {
     const { analyzeSql } = await loadAnalyzer();
     await expect(analyzeSql({ sql: 'SELECT 1', dialect: 'unsupported' as never })).rejects.toThrow(
-      /Invalid dialect/
+      /Invalid dialect: unsupported/
     );
+    expect(wasmModuleMock.analyze_sql_json).not.toHaveBeenCalled();
+  });
+
+  it('accepts Oracle dialect requests', async () => {
+    const { analyzeSql } = await loadAnalyzer();
+
+    await analyzeSql({ sql: 'SELECT 1 FROM dual', dialect: 'oracle' });
+
+    const payloadJson = wasmModuleMock.analyze_sql_json.mock.calls[0]?.[0];
+    expect(payloadJson).toBeDefined();
+    const payload = JSON.parse(payloadJson as string);
+    expect(payload.dialect).toBe('oracle');
   });
 
   it('throws when wasm returns malformed JSON', async () => {

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -19,7 +19,7 @@ Hover over any table or column in your SQL file to see:
 
 ### ⚙️ Multi-Dialect Support
 Supports parsing for a wide range of SQL dialects including:
-- PostgreSQL, MySQL, SQLite
+- PostgreSQL, MySQL, SQLite, Oracle
 - Snowflake, BigQuery, Redshift
 - Databricks, DuckDB, ClickHouse
 - T-SQL (MSSQL), Hive, ANSI SQL

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -44,6 +44,7 @@
             "hive",
             "mssql",
             "mysql",
+            "oracle",
             "postgres",
             "redshift",
             "snowflake",
@@ -84,7 +85,7 @@
     "build:webview": "cd webview-ui && npm run build",
     "watch": "node esbuild.js --watch",
     "typecheck": "tsc --noEmit",
-    "test": "tsc -p tsconfig.test.json && node --test .test-dist/tests/statementScopedLineage.test.js",
+    "test": "tsc -p tsconfig.test.json && node --test .test-dist/tests/statementScopedLineage.test.js .test-dist/tests/dialects.test.js",
     "package": "vsce package"
   },
   "devDependencies": {

--- a/vscode/src/providers/completion.ts
+++ b/vscode/src/providers/completion.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { completionItems, isWasmInitialized } from '../analysis';
+import { VALID_DIALECTS } from '../types';
 import type { CompletionItem as FlowscopeCompletionItem, Dialect } from '../types';
 
 /**
@@ -98,22 +99,6 @@ function resolveReplaceRange(
   const to = Math.max(from, clamp(token.span.end));
   return new vscode.Range(document.positionAt(from), document.positionAt(to));
 }
-
-const VALID_DIALECTS: readonly Dialect[] = [
-  'generic',
-  'ansi',
-  'bigquery',
-  'clickhouse',
-  'databricks',
-  'duckdb',
-  'hive',
-  'mssql',
-  'mysql',
-  'postgres',
-  'redshift',
-  'snowflake',
-  'sqlite',
-];
 
 function resolveDialect(config: vscode.WorkspaceConfiguration): Dialect {
   const raw = config.get<string>('dialect', 'generic');

--- a/vscode/src/types.ts
+++ b/vscode/src/types.ts
@@ -3,20 +3,24 @@
  * Copied from @pondpilot/flowscope-core for standalone VSCode extension use.
  */
 
-export type Dialect =
-  | 'generic'
-  | 'ansi'
-  | 'bigquery'
-  | 'clickhouse'
-  | 'databricks'
-  | 'duckdb'
-  | 'hive'
-  | 'mssql'
-  | 'mysql'
-  | 'postgres'
-  | 'redshift'
-  | 'snowflake'
-  | 'sqlite';
+export const VALID_DIALECTS = [
+  'generic',
+  'ansi',
+  'bigquery',
+  'clickhouse',
+  'databricks',
+  'duckdb',
+  'hive',
+  'mssql',
+  'mysql',
+  'oracle',
+  'postgres',
+  'redshift',
+  'snowflake',
+  'sqlite',
+] as const;
+
+export type Dialect = (typeof VALID_DIALECTS)[number];
 
 export interface AnalyzeRequest {
   sql: string;

--- a/vscode/tests/dialects.test.ts
+++ b/vscode/tests/dialects.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import packageJson from '../package.json';
+import { VALID_DIALECTS } from '../src/types';
+
+describe('dialects', () => {
+  it('keeps the VS Code setting choices synchronized with runtime dialects', () => {
+    const setting = packageJson.contributes.configuration.properties['flowscope.dialect'];
+
+    assert.deepEqual(setting.enum, VALID_DIALECTS);
+  });
+
+  it('includes Oracle', () => {
+    assert.ok(VALID_DIALECTS.includes('oracle'));
+  });
+});


### PR DESCRIPTION
## Summary

- derive the public TypeScript `Dialect` type and runtime validation from one exported `VALID_DIALECTS` list
- reuse the core dialect list in the demo app and synchronize Oracle across the standalone VS Code type, runtime guard, and settings manifest
- add Oracle acceptance, invalid-value rejection, and VS Code manifest synchronization coverage
- correct only the user-facing dialect-support documentation that still omitted or described Oracle as unsupported

## Root cause

Oracle was present in the Rust enum and public TypeScript type, but `packages/core/src/analyzer.ts` maintained a separate runtime list without `oracle`. Valid requests were rejected before reaching WASM.

## Validation

- `yarn workspace @pondpilot/flowscope-core build:no-wasm`
- `yarn workspace @pondpilot/flowscope-core test` — 42 tests passed
- `yarn workspace @pondpilot/flowscope-core lint`
- `yarn workspace @pondpilot/flowscope-core typecheck`
- `yarn workspace @pondpilot/flowscope-app test` — 328 tests passed
- `yarn workspace @pondpilot/flowscope-app lint`
- `yarn workspace @pondpilot/flowscope-app typecheck`
- `npm test` in `vscode/` — 4 tests passed
- `npm run typecheck` in `vscode/`
- targeted Prettier check and `git diff --check`