### PR TITLE
ci: enforce TypeScript quality gates and publish React

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
           name: wasm-module
           path: packages/core/wasm/
 
-  typescript-build:
-    name: TypeScript Build
+  typescript:
+    name: TypeScript
     runs-on: ubuntu-latest
     needs: wasm-build
     steps:
@@ -164,10 +164,25 @@ jobs:
           path: packages/core/wasm/
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Build core package (skip WASM rebuild)
         run: yarn workspace @pondpilot/flowscope-core build:no-wasm
+
+      - name: Build React package
+        run: yarn workspace @pondpilot/flowscope-react build
+
+      - name: Check formatting
+        run: yarn prettier
+
+      - name: Run ESLint
+        run: yarn workspaces run lint
+
+      - name: Run typechecks
+        run: yarn workspaces run typecheck
+
+      - name: Run tests
+        run: yarn test:ts
 
       - name: Build demo app
         run: yarn workspace @pondpilot/flowscope-app build
@@ -194,27 +209,6 @@ jobs:
         run: |
           cargo test -p flowscope-core --test schema_guard --locked
           cd packages/core && yarn test schema-compat.test.ts --silent
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Run ESLint
-        run: yarn lint || true
-
-      - name: Run Prettier check
-        run: yarn prettier --check . || true
 
   cli-serve:
     name: CLI Serve Mode
@@ -274,6 +268,12 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
       - name: Cache Cargo
         uses: actions/cache@v4
         with:
@@ -288,10 +288,16 @@ jobs:
       - name: Generate coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
+      - name: Install JS dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate app coverage
+        run: yarn workspace @pondpilot/flowscope-app test:coverage
+
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: lcov.info
+          files: lcov.info,app/coverage/lcov.info
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,14 +135,23 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-wasm-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build WASM
+      - name: Build browser WASM
         run: wasm-pack build crates/flowscope-wasm --target web --out-dir ../../packages/core/wasm
+
+      - name: Build Node.js WASM
+        run: wasm-pack build crates/flowscope-wasm --target nodejs --no-opt --out-dir ../../vscode/wasm-node
 
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:
           name: wasm-module
           path: packages/core/wasm/
+
+      - name: Upload Node.js WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-node-module
+          path: vscode/wasm-node/
 
   typescript:
     name: TypeScript
@@ -157,14 +166,26 @@ jobs:
           node-version: '20'
           cache: 'yarn'
 
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install VS Code extension dependencies
+        run: npm ci --prefix vscode
+
+      - name: Check formatting
+        run: yarn prettier
+
       - name: Download WASM artifact
         uses: actions/download-artifact@v4
         with:
           name: wasm-module
           path: packages/core/wasm/
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - name: Download Node.js WASM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-node-module
+          path: vscode/wasm-node/
 
       - name: Build core package (skip WASM rebuild)
         run: yarn workspace @pondpilot/flowscope-core build:no-wasm
@@ -172,17 +193,18 @@ jobs:
       - name: Build React package
         run: yarn workspace @pondpilot/flowscope-react build
 
-      - name: Check formatting
-        run: yarn prettier
-
       - name: Run ESLint
         run: yarn workspaces run lint
 
       - name: Run typechecks
-        run: yarn workspaces run typecheck
+        run: |
+          yarn workspaces run typecheck
+          npm --prefix vscode run typecheck
 
       - name: Run tests
-        run: yarn test:ts
+        run: |
+          yarn test:ts
+          npm --prefix vscode run test
 
       - name: Build demo app
         run: yarn workspace @pondpilot/flowscope-app build

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -155,4 +155,13 @@ jobs:
 
       - name: Publish npm package (react)
         if: ${{ env.DRY_RUN != 'true' }}
-        run: echo "Skipping @pondpilot/flowscope-react publish."
+        working-directory: packages/react
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "@pondpilot/flowscope-react@${VERSION}" version >/dev/null 2>&1; then
+            echo "@pondpilot/flowscope-react@${VERSION} already published; skipping."
+          else
+            npm publish --workspaces=false
+          fi
+        env:
+          NODE_AUTH_TOKEN: ''

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ build/
 
 # WASM build artifacts
 packages/core/src/wasm/
+vscode/wasm-node/
+vscode/.test-dist/
 *.wasm
 pkg/
 !packages/core/wasm/

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"
   },
   "dependencies": {
@@ -54,6 +55,7 @@
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.4.0",
+    "@vitest/coverage-v8": "3.2.4",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.0",

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/features/librarian/__tests__/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+      reporter: ['text', ['lcov', { projectRoot: path.resolve(__dirname, '..') }]],
+      reportsDirectory: './coverage',
+    },
     alias: {
       '@pondpilot/flowscope-core': path.resolve(
         __dirname,

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,4 +13,3 @@ ignore:
   - "packages/core/src/wasm/**"
   - "**/generated/**"
   - "**/tests/**"
-  - "app/**"

--- a/crates/flowscope-core/specs/dialect-semantics/dialects.json
+++ b/crates/flowscope-core/specs/dialect-semantics/dialects.json
@@ -199,7 +199,15 @@
   },
   "oracle": {
     "normalization": "uppercase",
-    "pseudocolumns": ["LEVEL", "OBJECT_ID", "OBJECT_VALUE", "ROWID", "ROWNUM", "SYSDATE", "SYSTIMESTAMP"],
+    "pseudocolumns": [
+      "LEVEL",
+      "OBJECT_ID",
+      "OBJECT_VALUE",
+      "ROWID",
+      "ROWNUM",
+      "SYSDATE",
+      "SYSTIMESTAMP"
+    ],
     "pseudo_tables": ["DUAL"],
     "quote_chars": {
       "identifier_quotes": ["\""],

--- a/crates/flowscope-core/tests/fixtures/schemas/oracle_sample.json
+++ b/crates/flowscope-core/tests/fixtures/schemas/oracle_sample.json
@@ -17,28 +17,17 @@
     {
       "schema": "IDM",
       "name": "REG_SUBJECTTYPE",
-      "columns": [
-        { "name": "ID_SUBJECTTYPE" },
-        { "name": "IS_ACTIVE" },
-        { "name": "NAME" }
-      ]
+      "columns": [{ "name": "ID_SUBJECTTYPE" }, { "name": "IS_ACTIVE" }, { "name": "NAME" }]
     },
     {
       "schema": "IDM",
       "name": "REG_SUBJECT_INFO",
-      "columns": [
-        { "name": "ID_SUBJECT" },
-        { "name": "ID_SUBJECTTYPE" }
-      ]
+      "columns": [{ "name": "ID_SUBJECT" }, { "name": "ID_SUBJECTTYPE" }]
     },
     {
       "schema": "IDM",
       "name": "SUBJECT",
-      "columns": [
-        { "name": "ID" },
-        { "name": "ID_SUBJECTTYPE" },
-        { "name": "NAME" }
-      ]
+      "columns": [{ "name": "ID" }, { "name": "ID_SUBJECTTYPE" }, { "name": "NAME" }]
     },
     {
       "schema": "CORE",
@@ -53,88 +42,52 @@
     {
       "schema": "BMRT_META",
       "name": "REG_DEAL",
-      "columns": [
-        { "name": "ID" },
-        { "name": "ID_DEAL" },
-        { "name": "DEAL_NUMB" }
-      ]
+      "columns": [{ "name": "ID" }, { "name": "ID_DEAL" }, { "name": "DEAL_NUMB" }]
     },
     {
       "schema": "BMRT",
       "name": "REG_DEAL",
-      "columns": [
-        { "name": "ID_DEAL" },
-        { "name": "DEAL_NUMB" }
-      ]
+      "columns": [{ "name": "ID_DEAL" }, { "name": "DEAL_NUMB" }]
     },
     {
       "schema": "BMRT",
       "name": "DEAL",
-      "columns": [
-        { "name": "ID" },
-        { "name": "DT_FROM" }
-      ]
+      "columns": [{ "name": "ID" }, { "name": "DT_FROM" }]
     },
     {
       "schema": "STG",
       "name": "BILLING_SYSTEM",
-      "columns": [
-        { "name": "TXN_ID" },
-        { "name": "AMOUNT" },
-        { "name": "TXN_DATE" }
-      ]
+      "columns": [{ "name": "TXN_ID" }, { "name": "AMOUNT" }, { "name": "TXN_DATE" }]
     },
     {
       "schema": "STG",
       "name": "CRM_SYSTEM",
-      "columns": [
-        { "name": "TXN_ID" },
-        { "name": "AMOUNT" },
-        { "name": "TXN_DATE" }
-      ]
+      "columns": [{ "name": "TXN_ID" }, { "name": "AMOUNT" }, { "name": "TXN_DATE" }]
     },
     {
       "schema": "DQ",
       "name": "MISSING_TRANSACTIONS",
-      "columns": [
-        { "name": "TXN_ID" },
-        { "name": "AMOUNT" },
-        { "name": "TXN_DATE" }
-      ]
+      "columns": [{ "name": "TXN_ID" }, { "name": "AMOUNT" }, { "name": "TXN_DATE" }]
     },
     {
       "schema": "SALES",
       "name": "TRANSACTIONS",
-      "columns": [
-        { "name": "DATE_ID" },
-        { "name": "AMOUNT" },
-        { "name": "MONTH_NAME" }
-      ]
+      "columns": [{ "name": "DATE_ID" }, { "name": "AMOUNT" }, { "name": "MONTH_NAME" }]
     },
     {
       "schema": "DIMS",
       "name": "CALENDAR",
-      "columns": [
-        { "name": "DATE_ID" },
-        { "name": "MONTH_NAME" }
-      ]
+      "columns": [{ "name": "DATE_ID" }, { "name": "MONTH_NAME" }]
     },
     {
       "schema": "SALES",
       "name": "CUSTOMERS",
-      "columns": [
-        { "name": "CUSTOMER_ID" },
-        { "name": "CUSTOMER_NAME" }
-      ]
+      "columns": [{ "name": "CUSTOMER_ID" }, { "name": "CUSTOMER_NAME" }]
     },
     {
       "schema": "SALES",
       "name": "ORDERS",
-      "columns": [
-        { "name": "CUSTOMER_ID" },
-        { "name": "AMOUNT" },
-        { "name": "ORDER_ID" }
-      ]
+      "columns": [{ "name": "CUSTOMER_ID" }, { "name": "AMOUNT" }, { "name": "ORDER_ID" }]
     },
     {
       "schema": "HR",
@@ -161,11 +114,7 @@
     {
       "schema": "HR",
       "name": "LOCATIONS",
-      "columns": [
-        { "name": "LOCATION_ID" },
-        { "name": "CITY" },
-        { "name": "STATE_PROVINCE" }
-      ]
+      "columns": [{ "name": "LOCATION_ID" }, { "name": "CITY" }, { "name": "STATE_PROVINCE" }]
     },
     {
       "schema": "HR",
@@ -190,20 +139,12 @@
     {
       "schema": "PAY",
       "name": "BONUSES",
-      "columns": [
-        { "name": "EMP_ID" },
-        { "name": "BONUS_AMOUNT" },
-        { "name": "TYPE_ID" }
-      ]
+      "columns": [{ "name": "EMP_ID" }, { "name": "BONUS_AMOUNT" }, { "name": "TYPE_ID" }]
     },
     {
       "schema": "PAY",
       "name": "BONUS_TYPES",
-      "columns": [
-        { "name": "TYPE_ID" },
-        { "name": "MULTIPLIER" },
-        { "name": "TYPE_NAME" }
-      ]
+      "columns": [{ "name": "TYPE_ID" }, { "name": "MULTIPLIER" }, { "name": "TYPE_NAME" }]
     },
     {
       "schema": "DM",
@@ -218,18 +159,12 @@
     {
       "schema": "IDM",
       "name": "REG_DEAL",
-      "columns": [
-        { "name": "ID_DEAL" },
-        { "name": "DEAL_NUMB" }
-      ]
+      "columns": [{ "name": "ID_DEAL" }, { "name": "DEAL_NUMB" }]
     },
     {
       "schema": "UPL",
       "name": "DEAL",
-      "columns": [
-        { "name": "ID" },
-        { "name": "DEAL_NUMB" }
-      ]
+      "columns": [{ "name": "ID" }, { "name": "DEAL_NUMB" }]
     },
     {
       "schema": "PUBLIC",
@@ -244,20 +179,12 @@
     {
       "schema": "ARCHIVE",
       "name": "USER_LOGS",
-      "columns": [
-        { "name": "LOG_SEQ" },
-        { "name": "USERNAME_UPPER" },
-        { "name": "EVENT_TS" }
-      ]
+      "columns": [{ "name": "LOG_SEQ" }, { "name": "USERNAME_UPPER" }, { "name": "EVENT_TS" }]
     },
     {
       "schema": "TARGET_SCHEMA",
       "name": "TARGET_TABLE",
-      "columns": [
-        { "name": "ID" },
-        { "name": "NAME" },
-        { "name": "DT" }
-      ]
+      "columns": [{ "name": "ID" }, { "name": "NAME" }, { "name": "DT" }]
     },
     {
       "schema": "SOURCE_SCHEMA",
@@ -282,20 +209,12 @@
     {
       "schema": "CORE",
       "name": "EMPLOYEES",
-      "columns": [
-        { "name": "NAME" },
-        { "name": "AGE" },
-        { "name": "EMPLOYEE_ID" }
-      ]
+      "columns": [{ "name": "NAME" }, { "name": "AGE" }, { "name": "EMPLOYEE_ID" }]
     },
     {
       "schema": "IDM",
       "name": "EMPLOYEES_ALL",
-      "columns": [
-        { "name": "NAME1" },
-        { "name": "AGE1" },
-        { "name": "EMPLOYEE_ID1" }
-      ]
+      "columns": [{ "name": "NAME1" }, { "name": "AGE1" }, { "name": "EMPLOYEE_ID1" }]
     },
     {
       "name": "EMPLOYEES",
@@ -318,11 +237,7 @@
     },
     {
       "name": "TEST_VIEW_EXPLICIT",
-      "columns": [
-        { "name": "ID_SUBJECT" },
-        { "name": "CODE" },
-        { "name": "ID_SUBJECTTYPE" }
-      ]
+      "columns": [{ "name": "ID_SUBJECT" }, { "name": "CODE" }, { "name": "ID_SUBJECTTYPE" }]
     }
   ]
 }

--- a/justfile
+++ b/justfile
@@ -236,6 +236,13 @@ build-wasm-dev:
 build-ts:
     yarn build:ts
 
+# Build TypeScript workspace dependencies without rebuilding WASM
+_build-core-ts:
+    yarn workspace @pondpilot/flowscope-core build:no-wasm
+
+_build-react-ts: _build-core-ts
+    yarn workspace @pondpilot/flowscope-react build
+
 # Run all tests
 test: test-rust test-ts
 
@@ -260,8 +267,12 @@ test-core:
     cargo test -p flowscope-core
 
 # Run TypeScript tests
-test-ts:
+test-ts: _build-core-ts
     yarn test:ts
+
+# Generate app TypeScript coverage
+coverage-ts:
+    yarn workspace @pondpilot/flowscope-app test:coverage
 
 # Generate HTML coverage report (requires cargo-llvm-cov)
 coverage:
@@ -303,7 +314,7 @@ lint-fix:
     yarn workspaces run lint:fix
 
 # Run TypeScript type checking
-typecheck:
+typecheck: _build-react-ts
     yarn workspaces run typecheck
 
 # Format code
@@ -374,7 +385,7 @@ test-rust-release:
 run: build-wasm-dev build-ts dev
 
 # Check everything is working (quick validation)
-check: fmt-check-rust fmt-check-ts lint typecheck test-rust check-schema
+check: fmt-check-rust fmt-check-ts lint typecheck test-ts test-rust check-schema
 
 # All checks (Rust + TS + schema compatibility)
 check-all:

--- a/justfile
+++ b/justfile
@@ -243,6 +243,9 @@ _build-core-ts:
 _build-react-ts: _build-core-ts
     yarn workspace @pondpilot/flowscope-react build
 
+_build-vscode-wasm:
+    wasm-pack build crates/flowscope-wasm --target nodejs --no-opt --out-dir ../../vscode/wasm-node
+
 # Run all tests
 test: test-rust test-ts
 
@@ -269,6 +272,7 @@ test-core:
 # Run TypeScript tests
 test-ts: _build-core-ts
     yarn test:ts
+    npm --prefix vscode run test
 
 # Generate app TypeScript coverage
 coverage-ts:
@@ -314,8 +318,9 @@ lint-fix:
     yarn workspaces run lint:fix
 
 # Run TypeScript type checking
-typecheck: _build-react-ts
+typecheck: _build-react-ts _build-vscode-wasm
     yarn workspaces run typecheck
+    npm --prefix vscode run typecheck
 
 # Format code
 fmt: fmt-rust fmt-ts
@@ -348,6 +353,7 @@ clean:
 # Install dependencies
 install:
     yarn install
+    npm ci --prefix vscode
 
 # Install Rust tools (wasm-pack, cargo-watch, cargo-llvm-cov)
 install-rust-tools:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,14 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@ampproject/remapping@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
+  integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
 "@asamuzakjp/css-color@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
@@ -112,10 +120,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
@@ -136,6 +154,13 @@
   integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
   dependencies:
     "@babel/types" "^7.29.0"
+
+"@babel/parser@^7.25.4":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
+  dependencies:
+    "@babel/types" "^7.29.8"
 
 "@babel/plugin-transform-react-jsx-self@^7.27.1":
   version "7.27.1"
@@ -185,6 +210,19 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.25.4", "@babel/types@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+
+"@bcoe/v8-coverage@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz#bbe12dca5b4ef983a0d0af4b07b9bc90ea0ababa"
+  integrity sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==
 
 "@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.18.0":
   version "6.20.1"
@@ -578,6 +616,23 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -604,7 +659,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
+"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28", "@jridgewell/trace-mapping@^0.3.31":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -642,6 +697,11 @@
   integrity sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==
   dependencies:
     "@tybys/wasm-util" "^0.10.1"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@pondpilot/flowscope-core@file:packages/core":
   version "0.8.0"
@@ -1796,6 +1856,25 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
 
+"@vitest/coverage-v8@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz#a2d8d040288c1956a1c7d0a0e2cdcfc7a3319f13"
+  integrity sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==
+  dependencies:
+    "@ampproject/remapping" "^2.3.0"
+    "@bcoe/v8-coverage" "^1.0.2"
+    ast-v8-to-istanbul "^0.3.3"
+    debug "^4.4.1"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-lib-source-maps "^5.0.6"
+    istanbul-reports "^3.1.7"
+    magic-string "^0.30.17"
+    magicast "^0.3.5"
+    std-env "^3.9.0"
+    test-exclude "^7.0.1"
+    tinyrainbow "^2.0.0"
+
 "@vitest/expect@3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.4.tgz#8362124cd811a5ee11c5768207b9df53d34f2433"
@@ -1937,7 +2016,12 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^4.1.0:
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1948,6 +2032,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -1977,6 +2066,15 @@ assertion-error@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
   integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
+ast-v8-to-istanbul@^0.3.3:
+  version "0.3.12"
+  resolved "https://registry.yarnpkg.com/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz#8eb1b7c86ef8499859be761b17ffd91406c0c36f"
+  integrity sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.31"
+    estree-walker "^3.0.3"
+    js-tokens "^10.0.0"
 
 b4a@^1.6.4:
   version "1.8.0"
@@ -2062,6 +2160,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
+  dependencies:
+    balanced-match "^1.0.0"
 
 brace-expansion@^5.0.5:
   version "5.0.5"
@@ -2337,7 +2442,7 @@ data-urls@^5.0.0:
     whatwg-mimetype "^4.0.0"
     whatwg-url "^14.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2396,6 +2501,11 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 electron-to-chromium@^1.5.328:
   version "1.5.336"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz#d7c25c0827b8c5e2885b2c91ac6cdcf3e5a1386e"
@@ -2405,6 +2515,16 @@ elkjs@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.11.1.tgz#d27fcdbbf5a8aeeff80420d17d1666f78cfc8544"
   integrity sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.5"
@@ -2666,6 +2786,14 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 frac@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
@@ -2702,6 +2830,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@^10.4.1:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 globals@^14.0.0:
   version "14.0.0"
@@ -2741,6 +2881,11 @@ html-encoding-sniffer@^4.0.0:
   integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
   dependencies:
     whatwg-encoding "^3.1.1"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 html-to-image@^1.11.13:
   version "1.11.13"
@@ -2823,6 +2968,11 @@ is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-glob@^4.0.0, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
@@ -2840,10 +2990,55 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
+  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.23"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+
+istanbul-reports@^3.1.7:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
+
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -3034,7 +3229,7 @@ loupe@^3.1.0, loupe@^3.1.4:
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
   integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
 
-lru-cache@^10.4.3:
+lru-cache@^10.2.0, lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -3063,6 +3258,22 @@ magic-string@^0.30.17, magic-string@^0.30.21:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
+magicast@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.3.5.tgz#8301c3c7d66704a0771eb1bad74274f0ec036739"
+  integrity sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==
+  dependencies:
+    "@babel/parser" "^7.25.4"
+    "@babel/types" "^7.25.4"
+    source-map-js "^1.2.0"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -3087,10 +3298,22 @@ minimatch@^3.1.5:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
 minimist@^1.2.0, minimist@^1.2.3:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
@@ -3213,6 +3436,11 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3236,6 +3464,14 @@ path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path2d@^0.2.1:
   version "0.2.2"
@@ -3520,6 +3756,11 @@ semver@^7.3.5, semver@^7.5.4, semver@^7.7.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
+semver@^7.5.3:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+
 sharp@^0.32.0:
   version "0.32.6"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
@@ -3551,6 +3792,11 @@ siginfo@^2.0.0:
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 simple-concat@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
@@ -3577,7 +3823,7 @@ sonner@^2.0.7:
   resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
   integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
 
-source-map-js@^1.2.1:
+source-map-js@^1.2.0, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -3608,12 +3854,46 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -3724,6 +4004,15 @@ teex@^1.0.1:
   integrity sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==
   dependencies:
     streamx "^2.12.5"
+
+test-exclude@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.2.tgz#482392077630bc57d5630c13abe908bb910dfc65"
+  integrity sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^10.4.1"
+    minimatch "^10.2.2"
 
 text-decoder@^1.1.0:
   version "1.2.7"
@@ -4020,6 +4309,24 @@ word@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
## Summary

- enforce Prettier, ESLint, workspace typechecks, and workspace tests in the TypeScript CI job
- build core and React prerequisites before downstream gates and add TypeScript tests to `just check`
- generate app LCOV with Vitest, upload it with Rust coverage, and remove the obsolete Codecov app exclusion
- publish `@pondpilot/flowscope-react` after core with the same idempotent trusted-publishing flow
- format the two JSON files exposed by the new Prettier gate

## Root cause

CI built TypeScript artifacts but never ran the existing test or typecheck scripts. The lint job discarded ESLint and Prettier exit codes. Coverage only produced Rust LCOV while excluding the app, and the release workflow replaced the React publish with an echo.

## Validation

- `yarn install --frozen-lockfile`
- `just check`
- `just coverage-ts` (102 app source files in LCOV)
- `yarn workspace @pondpilot/flowscope-app build`
- `npm pack --dry-run --workspaces=false` for core and React
- `actionlint .github/workflows/ci.yml .github/workflows/publish-core.yml`

## Residual risk

Codecov remains informational and no new coverage threshold was added. The production npm publish path was not executed locally; package dry-runs, dependency order, auth convention, and workflow syntax were validated.