### PR TITLE
ci: enforce coverage and database integration gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,11 +276,46 @@ jobs:
       - name: Run CLI serve tests
         run: cargo test -p flowscope-cli --features serve
 
+  database-integration:
+    name: Database Integration (SQLite, PostgreSQL, MySQL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-database-integration-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run database integration tests
+        run: just test-integration
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Validate Codecov configuration
+        run: >-
+          curl --fail --show-error --silent --retry 3 --retry-all-errors --max-time 30
+          --data-binary @codecov.yml https://codecov.io/validate
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@1.95.0
@@ -317,9 +352,9 @@ jobs:
         run: yarn workspace @pondpilot/flowscope-app test:coverage
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          files: lcov.info,app/coverage/lcov.info
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
+          fail_ci_if_error: true
+          files: ./lcov.info,./app/coverage/lcov.info
+          use_oidc: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,27 @@
+codecov:
+  require_ci_to_pass: true
+
 coverage:
   status:
     project:
       default:
-        informational: true
+        # Baseline: 77.82% combined Rust and app line coverage on 2026-08-12.
+        target: 77%
+        threshold: 0.5%
+        if_ci_failed: error
+        if_not_found: failure
+        informational: false
     patch:
       default:
-        informational: true
+        target: 70%
+        threshold: 1%
+        if_ci_failed: error
+        if_not_found: failure
+        informational: false
 
 ignore:
-  - "crates/flowscope-wasm/**"
-  - "packages/core/wasm/**"
-  - "packages/core/src/wasm/**"
-  - "**/generated/**"
-  - "**/tests/**"
+  - 'crates/flowscope-wasm/**'
+  - 'packages/core/wasm/**'
+  - 'packages/core/src/wasm/**'
+  - '**/generated/**'
+  - '**/tests/**'

--- a/crates/flowscope-cli/tests/integration/main.rs
+++ b/crates/flowscope-cli/tests/integration/main.rs
@@ -147,6 +147,17 @@ pub fn assert_star_expansion(output: &Output, expected_columns: &[&str]) {
 
 /// Find a node by label and type in the JSON output.
 fn find_node_by_label(json: &serde_json::Value, label: &str, node_type: &str) -> bool {
+    // Check top-level nodes in the current response shape.
+    if let Some(nodes) = json.get("nodes").and_then(|n| n.as_array()) {
+        for node in nodes {
+            let node_label = node.get("label").and_then(|l| l.as_str()).unwrap_or("");
+            let ntype = node.get("type").and_then(|t| t.as_str()).unwrap_or("");
+            if node_label == label && ntype == node_type {
+                return true;
+            }
+        }
+    }
+
     // Check in statements array
     if let Some(statements) = json.get("statements").and_then(|s| s.as_array()) {
         for stmt in statements {

--- a/justfile
+++ b/justfile
@@ -116,7 +116,9 @@ test-integration-postgres: _postgres-start
     "
 
     # Run tests
-    cargo test -p flowscope-cli --features integration-tests --test integration postgres -- --test-threads=1
+    postgres_port="${TEST_POSTGRES_PORT:-5433}"
+    TEST_POSTGRES_URL="postgres://flowscope:flowscope@127.0.0.1:${postgres_port}/flowscope" \
+        cargo test -p flowscope-cli --features integration-tests --test integration postgres -- --test-threads=1
 
     # Stop PostgreSQL
     just _postgres-stop
@@ -129,16 +131,17 @@ _postgres-start:
     # Stop existing container if running
     docker rm -f flowscope-test-postgres 2>/dev/null || true
 
-    # Start PostgreSQL on port 5433 to avoid conflicts
+    # Start PostgreSQL on the configurable test port
+    postgres_port="${TEST_POSTGRES_PORT:-5433}"
     docker run -d \
         --name flowscope-test-postgres \
         -e POSTGRES_USER=flowscope \
         -e POSTGRES_PASSWORD=flowscope \
         -e POSTGRES_DB=flowscope \
-        -p 5433:5432 \
+        -p "127.0.0.1:${postgres_port}:5432" \
         postgres:16-alpine
 
-    echo "PostgreSQL container started on port 5433"
+    echo "PostgreSQL container started on port ${postgres_port}"
 
 # Stop PostgreSQL container
 _postgres-stop:
@@ -195,7 +198,9 @@ test-integration-mysql: _mysql-start
     "
 
     # Run tests
-    cargo test -p flowscope-cli --features integration-tests --test integration mysql -- --test-threads=1
+    mysql_port="${TEST_MYSQL_PORT:-3307}"
+    TEST_MYSQL_URL="mysql://flowscope:flowscope@127.0.0.1:${mysql_port}/flowscope" \
+        cargo test -p flowscope-cli --features integration-tests --test integration mysql -- --test-threads=1
 
     # Stop MySQL
     just _mysql-stop
@@ -208,17 +213,18 @@ _mysql-start:
     # Stop existing container if running
     docker rm -f flowscope-test-mysql 2>/dev/null || true
 
-    # Start MySQL on port 3307 to avoid conflicts
+    # Start MySQL on the configurable test port
+    mysql_port="${TEST_MYSQL_PORT:-3307}"
     docker run -d \
         --name flowscope-test-mysql \
         -e MYSQL_ROOT_PASSWORD=root \
         -e MYSQL_USER=flowscope \
         -e MYSQL_PASSWORD=flowscope \
         -e MYSQL_DATABASE=flowscope \
-        -p 3307:3306 \
+        -p "127.0.0.1:${mysql_port}:3306" \
         mysql:8.0
 
-    echo "MySQL container started on port 3307"
+    echo "MySQL container started on port ${mysql_port}"
 
 # Stop MySQL container
 _mysql-stop:
@@ -277,6 +283,10 @@ test-ts: _build-core-ts
 # Generate app TypeScript coverage
 coverage-ts:
     yarn workspace @pondpilot/flowscope-app test:coverage
+
+# Validate the repository Codecov configuration against Codecov's schema
+validate-codecov:
+    curl --fail --show-error --silent --retry 3 --retry-all-errors --max-time 30 --data-binary @codecov.yml https://codecov.io/validate
 
 # Generate HTML coverage report (requires cargo-llvm-cov)
 coverage:

--- a/justfile
+++ b/justfile
@@ -71,17 +71,25 @@ test-integration-sqlite:
 test-integration-postgres: _postgres-start
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'just _postgres-stop' EXIT
 
-    # Wait for PostgreSQL to be ready
+    # Require consecutive successful queries so the entrypoint's temporary
+    # bootstrap server is not mistaken for the final PostgreSQL process.
     echo "Waiting for PostgreSQL to be ready..."
+    ready_checks=0
     for i in {1..30}; do
-        if docker exec flowscope-test-postgres pg_isready -U flowscope > /dev/null 2>&1; then
-            echo "PostgreSQL is ready"
-            break
+        if docker exec flowscope-test-postgres \
+            psql -U flowscope -d flowscope -c "SELECT 1" > /dev/null 2>&1; then
+            ready_checks=$((ready_checks + 1))
+            if [ "$ready_checks" -ge 3 ]; then
+                echo "PostgreSQL is ready"
+                break
+            fi
+        else
+            ready_checks=0
         fi
         if [ $i -eq 30 ]; then
             echo "PostgreSQL failed to start"
-            just _postgres-stop
             exit 1
         fi
         sleep 1
@@ -120,9 +128,6 @@ test-integration-postgres: _postgres-start
     TEST_POSTGRES_URL="postgres://flowscope:flowscope@127.0.0.1:${postgres_port}/flowscope" \
         cargo test -p flowscope-cli --features integration-tests --test integration postgres -- --test-threads=1
 
-    # Stop PostgreSQL
-    just _postgres-stop
-
 # Start PostgreSQL container for integration tests
 _postgres-start:
     #!/usr/bin/env bash
@@ -151,17 +156,23 @@ _postgres-stop:
 test-integration-mysql: _mysql-start
     #!/usr/bin/env bash
     set -euo pipefail
+    trap 'just _mysql-stop' EXIT
 
-    # Wait for MySQL to be ready (check with actual user connection, not just ping)
+    # Require consecutive successful user queries to avoid bootstrap races.
     echo "Waiting for MySQL to be ready..."
+    ready_checks=0
     for i in {1..60}; do
         if docker exec flowscope-test-mysql mysql -uflowscope -pflowscope -e "SELECT 1" > /dev/null 2>&1; then
-            echo "MySQL is ready"
-            break
+            ready_checks=$((ready_checks + 1))
+            if [ "$ready_checks" -ge 3 ]; then
+                echo "MySQL is ready"
+                break
+            fi
+        else
+            ready_checks=0
         fi
         if [ $i -eq 60 ]; then
             echo "MySQL failed to start"
-            just _mysql-stop
             exit 1
         fi
         sleep 1
@@ -201,9 +212,6 @@ test-integration-mysql: _mysql-start
     mysql_port="${TEST_MYSQL_PORT:-3307}"
     TEST_MYSQL_URL="mysql://flowscope:flowscope@127.0.0.1:${mysql_port}/flowscope" \
         cargo test -p flowscope-cli --features integration-tests --test integration mysql -- --test-threads=1
-
-    # Stop MySQL
-    just _mysql-stop
 
 # Start MySQL container for integration tests
 _mysql-start:


### PR DESCRIPTION
## What changed

- make Codecov project and patch statuses non-informational and fail when reports or CI are missing
- enforce a 77% project target with 0.5-point tolerance and a 70% patch target with 1-point tolerance
- validate codecov.yml during the coverage job and upload with Codecov v5 OIDC, explicit reports, and fail_ci_if_error enabled
- add a blocking, cached, 25-minute database integration job for SQLite, PostgreSQL, and MySQL
- support configurable local PostgreSQL and MySQL test ports while preserving current defaults
- update the integration helper for the current top-level lineage node response shape

## Why

The latest master coverage job logged a rejected Codecov upload because the protected branch required authentication, but fail_ci_if_error was false and the job passed. Codecov statuses were also informational, and CI never ran the feature-gated database integration suite.

The measured baseline is 77.82% combined line coverage after applying the existing Codecov exclusions (68,106 covered of 87,518 coverable lines). The selected thresholds leave conservative measurement headroom while blocking meaningful project regressions and poorly tested patches.

## Database scope

The new job runs all database suites supported by the existing Docker-backed just recipes: 6 SQLite, 7 PostgreSQL, and 6 MySQL tests. Health-check loops and the job timeout bound failures; Cargo artifacts are cached.

The separately ignored tests in crates/flowscope-cli/tests/metadata_provider.rs remain omitted. They are legacy manual-service tests with no existing fixture initialization path; the feature-gated integration suite covers the same providers with reliable ephemeral setup.

## Validation

- actionlint 1.7.12 .github/workflows/ci.yml
- live Codecov configuration validation
- cargo fmt --all -- --check
- Prettier check for workflow and Codecov YAML
- git diff --check
- cargo test -p flowscope-cli --features integration-tests --test integration sqlite --no-run
- just test-integration with alternate local ports: 19 passed
- just coverage-lcov
- just coverage-ts: 23 files, 344 tests passed
- codex review --uncommitted: clean, no actionable findings
