### PR TITLE
fix(react): stabilize lineage store subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### TypeScript API, Web App, and VS Code Extension
 
+- **Stable React store subscriptions** — added selector overloads for lineage state and actions, stabilized the legacy `useLineage()` object references, and prevented prop synchronization effects from rerunning on unrelated store updates
 - **Oracle dialect validation** — accepted `oracle` requests in the TypeScript runtime and synchronized Oracle across the app, VS Code settings, and supported-dialect documentation
 
 ## [0.8.0] - 2026-08-11

--- a/app/src/hooks/__tests__/useAnalysis.test.tsx
+++ b/app/src/hooks/__tests__/useAnalysis.test.tsx
@@ -18,10 +18,9 @@ let currentProject: Project | null = null;
 let activeProjectId: string | null = null;
 
 vi.mock('@pondpilot/flowscope-react', () => ({
-  useLineage: () => ({
-    state: { hideCTEs: false },
-    actions: lineageActions,
-  }),
+  useLineageState: (selector: (state: { hideCTEs: boolean }) => unknown) =>
+    selector({ hideCTEs: false }),
+  useLineageActions: () => lineageActions,
 }));
 
 vi.mock('@/lib/project-store', () => ({

--- a/app/src/hooks/useAnalysis.ts
+++ b/app/src/hooks/useAnalysis.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef, startTransition } from 'react';
 import type { AnalyzeResult } from '@pondpilot/flowscope-core';
-import { useLineage } from '@pondpilot/flowscope-react';
+import { useLineageActions, useLineageState } from '@pondpilot/flowscope-react';
 import { analyzeWithWorker, getCachedAnalysis, syncAnalysisFiles } from '@/lib/analysis-worker';
 import type { BackendAdapter, AnalysisPayload } from '@/lib/backend-adapter';
 import { useProject } from '@/lib/project-store';
@@ -50,8 +50,8 @@ export interface UseAnalysisOptions {
 export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions) {
   const adapter = options?.adapter;
   const { currentProject, activeProjectId, backendSchema } = useProject();
-  const { actions, state: lineageState } = useLineage();
-  const { hideCTEs } = lineageState;
+  const actions = useLineageActions();
+  const hideCTEs = useLineageState((state) => state.hideCTEs);
   const { getResult, setResult: storeResult, setMetrics } = useAnalysisStore();
   const getViewState = useViewStateStore((s) => s.getViewState);
   const enableLinting = activeProjectId
@@ -64,12 +64,6 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
   });
   const analysisRequestRef = useRef(0);
   const attemptedCacheIdentityRef = useRef<AnalysisCacheIdentity | null>(null);
-
-  // Use ref for actions to avoid dependency issues (actions object changes every render)
-  const actionsRef = useRef(actions);
-  useEffect(() => {
-    actionsRef.current = actions;
-  }, [actions]);
 
   const setAnalyzing = useCallback((isAnalyzing: boolean) => {
     setState((prev) => ({ ...prev, isAnalyzing }));
@@ -277,13 +271,13 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
 
     if (!activeProjectId || !canUseMemoryCache) {
       attemptedCacheIdentityRef.current = null;
-      actionsRef.current.setResult(null);
+      actions.setResult(null);
       return;
     }
 
     if (!currentAnalysisCacheKey) {
       if (attemptedCacheIdentityRef.current?.projectId !== activeProjectId) {
-        actionsRef.current.setResult(null);
+        actions.setResult(null);
         attemptedCacheIdentityRef.current = { projectId: activeProjectId, cacheKey: null };
       }
       return;
@@ -307,12 +301,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     // Use startTransition to make the result update low-priority,
     // allowing UI interactions and worker callbacks to proceed without blocking
     startTransition(() => {
-      actionsRef.current.setResult(restoreDecision.result);
+      actions.setResult(restoreDecision.result);
       if (restoreDecision.result && currentAnalysisInput) {
-        actionsRef.current.setAnalyzedContent(
+        actions.setAnalyzedContent(
           new Map(currentAnalysisInput.context.files.map((file) => [file.name, file.content]))
         );
-        actionsRef.current.setStalePaths([]);
+        actions.setStalePaths([]);
       }
     });
   }, [
@@ -323,6 +317,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     currentAnalysisCacheKey,
     currentAnalysisInput,
     getResult,
+    actions,
   ]);
 
   // Check worker's IndexedDB cache for persisted analysis results.
@@ -400,14 +395,12 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         // Use startTransition to make the result update low-priority,
         // allowing UI interactions and worker callbacks to proceed without blocking
         startTransition(() => {
-          actionsRef.current.setResult(cached.result);
+          actions.setResult(cached.result);
           // Cache hits imply the current file content already matches what
           // was analyzed (cache key is content-derived), so seed the
           // staleness snapshot from the live files used to build `context`.
-          actionsRef.current.setAnalyzedContent(
-            new Map(context.files.map((f) => [f.name, f.content]))
-          );
-          actionsRef.current.setStalePaths([]);
+          actions.setAnalyzedContent(new Map(context.files.map((f) => [f.name, f.content])));
+          actions.setStalePaths([]);
         });
         if (canUseMemoryCache) {
           storeResult(activeProjectId, cacheKey, cached.result);
@@ -439,6 +432,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
     setMetrics,
     backendReady,
     adapter,
+    actions,
   ]);
 
   const runAnalysis = useCallback(
@@ -501,9 +495,9 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
           const representativeSql = context.files
             .map((f) => `-- File: ${f.name}\n${f.content}`)
             .join('\n\n');
-          actionsRef.current.setSql(representativeSql);
+          actions.setSql(representativeSql);
         } else if (activeFileContent) {
-          actionsRef.current.setSql(activeFileContent);
+          actions.setSql(activeFileContent);
         }
 
         const cachedResult =
@@ -511,11 +505,11 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
         const knownCacheKey = cachedResult ? cacheKey : null;
         const displayResult = (result: AnalyzeResult) => {
           startTransition(() => {
-            actionsRef.current.setResult(result);
-            actionsRef.current.setAnalyzedContent(
+            actions.setResult(result);
+            actions.setAnalyzedContent(
               new Map(context.files.map((file) => [file.name, file.content]))
             );
-            actionsRef.current.setStalePaths([]);
+            actions.setStalePaths([]);
           });
         };
 
@@ -633,6 +627,7 @@ export function useAnalysis(backendReady: boolean, options?: UseAnalysisOptions)
       setError,
       canUseMemoryCache,
       adapter,
+      actions,
     ]
   );
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -22,3 +22,18 @@ import { LineageExplorer } from '@pondpilot/flowscope-react';
 ```
 
 See the root [README](../../README.md) for more details.
+
+## Store hooks
+
+`LineageProvider` continues to support the structured `useLineage()` API. For
+components that only need part of the store, use selector-based state and
+action hooks so unrelated updates do not rerender the component:
+
+```tsx
+const selectedNodeId = useLineageState((state) => state.selectedNodeId);
+const selectNode = useLineageActions((actions) => actions.selectNode);
+```
+
+Calling `useLineageState()` or `useLineageActions()` without a selector remains
+supported. Their returned objects are referentially stable until a selected
+state field or action changes.

--- a/packages/react/src/components/LineageExplorer.tsx
+++ b/packages/react/src/components/LineageExplorer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, type JSX } from 'react';
-import { useLineage } from '../store';
+import { useLineageActions } from '../store';
 import { LineageProvider } from '../context';
 import { GraphView } from './GraphView';
 import { SqlView } from './SqlView';
@@ -16,7 +16,7 @@ interface LineageExplorerInnerProps {
   onCompletionError?: LineageExplorerProps['onCompletionError'];
 }
 
-function LineageExplorerInner({
+export function LineageExplorerInner({
   result,
   sql,
   onSqlChange,
@@ -25,15 +25,16 @@ function LineageExplorerInner({
   disableCompletion,
   onCompletionError,
 }: LineageExplorerInnerProps): JSX.Element {
-  const { actions } = useLineage();
+  const setResult = useLineageActions((actions) => actions.setResult);
+  const setSql = useLineageActions((actions) => actions.setSql);
 
   useEffect(() => {
-    actions.setResult(result);
-  }, [result, actions]);
+    setResult(result);
+  }, [result, setResult]);
 
   useEffect(() => {
-    actions.setSql(sql);
-  }, [sql, actions]);
+    setSql(sql);
+  }, [sql, setSql]);
 
   return (
     <div className="flowscope-explorer-inner">

--- a/packages/react/src/store.ts
+++ b/packages/react/src/store.ts
@@ -1,5 +1,6 @@
-import { createContext, createElement, useContext, type ReactNode } from 'react';
+import { createContext, createElement, useContext, useMemo, type ReactNode } from 'react';
 import { useStore } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
 import { createStore, type StoreApi } from 'zustand/vanilla';
 import type { AnalyzeResult, Span } from '@pondpilot/flowscope-core';
 import type {
@@ -11,6 +12,9 @@ import type {
   MatrixSubMode,
   TableFilterDirection,
   TableFilter,
+  LineageState as LineageContextState,
+  LineageActions as LineageContextActions,
+  LineageContextValue,
 } from './types';
 import { findMergedNodeById } from './utils/nodeOccurrences';
 
@@ -632,214 +636,117 @@ export function useLineageStore<T>(selector?: (state: LineageState) => T) {
   return useStore(store);
 }
 
-/**
- * Hook to access the full lineage store.
- * Compatible with the previous useLineage API for easier migration.
- */
-export function useLineage() {
-  const store = useLineageStore();
-
+function selectLineageState(store: LineageState): LineageContextState {
   return {
-    state: {
-      result: store.result,
-      sql: store.sql,
-      selectedNodeId: store.selectedNodeId,
-      selectedStatementIndex: store.selectedStatementIndex,
-      highlightedSpan: store.highlightedSpan,
-      focusedOccurrenceIndex: store.focusedOccurrenceIndex,
-      searchTerm: store.searchTerm,
-      viewMode: store.viewMode,
-      matrixSubMode: store.matrixSubMode,
-      layoutAlgorithm: store.layoutAlgorithm,
-      layoutMetrics: store.layoutMetrics,
-      graphMetrics: store.graphMetrics,
-      collapsedNodeIds: store.collapsedNodeIds,
-      expandedTableIds: store.expandedTableIds,
-      defaultCollapsed: store.defaultCollapsed,
-      showColumnEdges: store.showColumnEdges,
-      hideCTEs: store.hideCTEs,
-      showScriptTables: store.showScriptTables,
-      navigationRequest: store.navigationRequest,
-      visibleGraphNodeIds: store.visibleGraphNodeIds,
-      revealRequest: store.revealRequest,
-      tableFilter: store.tableFilter,
-      isLayouting: store.isLayouting,
-      isBuilding: store.isBuilding,
-      analyzedContentByPath: store.analyzedContentByPath,
-      stalePaths: store.stalePaths,
-    },
-    actions: {
-      setResult: store.setResult,
-      setSql: store.setSql,
-      selectNode: store.selectNode,
-      cycleOccurrence: store.cycleOccurrence,
-      focusOccurrence: store.focusOccurrence,
-      toggleNodeCollapse: store.toggleNodeCollapse,
-      setNodeCollapsed: store.setNodeCollapsed,
-      toggleTableExpansion: store.toggleTableExpansion,
-      setTableExpanded: store.setTableExpanded,
-      setAllNodesCollapsed: store.setAllNodesCollapsed,
-      selectStatement: store.selectStatement,
-      highlightSpan: store.highlightSpan,
-      setSearchTerm: store.setSearchTerm,
-      setViewMode: store.setViewMode,
-      setMatrixSubMode: store.setMatrixSubMode,
-      setLayoutAlgorithm: store.setLayoutAlgorithm,
-      setLayoutMetrics: store.setLayoutMetrics,
-      setGraphMetrics: store.setGraphMetrics,
-      toggleColumnEdges: store.toggleColumnEdges,
-      toggleHideCTEs: store.toggleHideCTEs,
-      toggleShowScriptTables: store.toggleShowScriptTables,
-      requestNavigation: store.requestNavigation,
-      setVisibleGraphNodeIds: store.setVisibleGraphNodeIds,
-      revealNodeInGraph: store.revealNodeInGraph,
-      clearRevealRequest: store.clearRevealRequest,
-      setTableFilter: store.setTableFilter,
-      toggleTableFilterSelection: store.toggleTableFilterSelection,
-      setTableFilterDirection: store.setTableFilterDirection,
-      clearTableFilter: store.clearTableFilter,
-      setIsLayouting: store.setIsLayouting,
-      setIsBuilding: store.setIsBuilding,
-      setAnalyzedContent: store.setAnalyzedContent,
-      setStalePaths: store.setStalePaths,
-    },
+    result: store.result,
+    sql: store.sql,
+    selectedNodeId: store.selectedNodeId,
+    selectedStatementIndex: store.selectedStatementIndex,
+    highlightedSpan: store.highlightedSpan,
+    focusedOccurrenceIndex: store.focusedOccurrenceIndex,
+    searchTerm: store.searchTerm,
+    viewMode: store.viewMode,
+    matrixSubMode: store.matrixSubMode,
+    layoutAlgorithm: store.layoutAlgorithm,
+    layoutMetrics: store.layoutMetrics,
+    graphMetrics: store.graphMetrics,
+    collapsedNodeIds: store.collapsedNodeIds,
+    expandedTableIds: store.expandedTableIds,
+    defaultCollapsed: store.defaultCollapsed,
+    showColumnEdges: store.showColumnEdges,
+    hideCTEs: store.hideCTEs,
+    showScriptTables: store.showScriptTables,
+    navigationRequest: store.navigationRequest,
+    visibleGraphNodeIds: store.visibleGraphNodeIds,
+    revealRequest: store.revealRequest,
+    tableFilter: store.tableFilter,
+    isLayouting: store.isLayouting,
+    isBuilding: store.isBuilding,
+    analyzedContentByPath: store.analyzedContentByPath,
+    stalePaths: store.stalePaths,
+  };
+}
+
+function selectLineageActions(store: LineageState): LineageContextActions {
+  return {
+    setResult: store.setResult,
+    setSql: store.setSql,
+    selectNode: store.selectNode,
+    cycleOccurrence: store.cycleOccurrence,
+    focusOccurrence: store.focusOccurrence,
+    toggleNodeCollapse: store.toggleNodeCollapse,
+    setNodeCollapsed: store.setNodeCollapsed,
+    toggleTableExpansion: store.toggleTableExpansion,
+    setTableExpanded: store.setTableExpanded,
+    setAllNodesCollapsed: store.setAllNodesCollapsed,
+    selectStatement: store.selectStatement,
+    highlightSpan: store.highlightSpan,
+    setSearchTerm: store.setSearchTerm,
+    setViewMode: store.setViewMode,
+    setMatrixSubMode: store.setMatrixSubMode,
+    setLayoutAlgorithm: store.setLayoutAlgorithm,
+    setLayoutMetrics: store.setLayoutMetrics,
+    setGraphMetrics: store.setGraphMetrics,
+    toggleColumnEdges: store.toggleColumnEdges,
+    toggleHideCTEs: store.toggleHideCTEs,
+    toggleShowScriptTables: store.toggleShowScriptTables,
+    requestNavigation: store.requestNavigation,
+    setVisibleGraphNodeIds: store.setVisibleGraphNodeIds,
+    revealNodeInGraph: store.revealNodeInGraph,
+    clearRevealRequest: store.clearRevealRequest,
+    setTableFilter: store.setTableFilter,
+    toggleTableFilterSelection: store.toggleTableFilterSelection,
+    setTableFilterDirection: store.setTableFilterDirection,
+    clearTableFilter: store.clearTableFilter,
+    setIsLayouting: store.setIsLayouting,
+    setIsBuilding: store.setIsBuilding,
+    setAnalyzedContent: store.setAnalyzedContent,
+    setStalePaths: store.setStalePaths,
   };
 }
 
 /**
- * Hook to access only the lineage state.
- * Note: This returns the store directly to avoid re-render issues.
- * Access individual properties as needed.
+ * Hook to access lineage state. Pass a selector to subscribe only to the
+ * fields a component consumes. The no-argument form preserves the legacy
+ * state object API and keeps its reference stable until a state field changes.
  */
-export function useLineageState() {
-  const result = useLineageStore((state) => state.result);
-  const sql = useLineageStore((state) => state.sql);
-  const selectedNodeId = useLineageStore((state) => state.selectedNodeId);
-  const selectedStatementIndex = useLineageStore((state) => state.selectedStatementIndex);
-  const highlightedSpan = useLineageStore((state) => state.highlightedSpan);
-  const focusedOccurrenceIndex = useLineageStore((state) => state.focusedOccurrenceIndex);
-  const searchTerm = useLineageStore((state) => state.searchTerm);
-  const viewMode = useLineageStore((state) => state.viewMode);
-  const matrixSubMode = useLineageStore((state) => state.matrixSubMode);
-  const layoutAlgorithm = useLineageStore((state) => state.layoutAlgorithm);
-  const layoutMetrics = useLineageStore((state) => state.layoutMetrics);
-  const graphMetrics = useLineageStore((state) => state.graphMetrics);
-  const collapsedNodeIds = useLineageStore((state) => state.collapsedNodeIds);
-  const expandedTableIds = useLineageStore((state) => state.expandedTableIds);
-  const defaultCollapsed = useLineageStore((state) => state.defaultCollapsed);
-  const showColumnEdges = useLineageStore((state) => state.showColumnEdges);
-  const hideCTEs = useLineageStore((state) => state.hideCTEs);
-  const showScriptTables = useLineageStore((state) => state.showScriptTables);
-  const navigationRequest = useLineageStore((state) => state.navigationRequest);
-  const visibleGraphNodeIds = useLineageStore((state) => state.visibleGraphNodeIds);
-  const revealRequest = useLineageStore((state) => state.revealRequest);
-  const tableFilter = useLineageStore((state) => state.tableFilter);
-  const isLayouting = useLineageStore((state) => state.isLayouting);
-  const isBuilding = useLineageStore((state) => state.isBuilding);
-  const analyzedContentByPath = useLineageStore((state) => state.analyzedContentByPath);
-  const stalePaths = useLineageStore((state) => state.stalePaths);
+export function useLineageState(): LineageContextState;
+export function useLineageState<T>(selector: (state: LineageContextState) => T): T;
+export function useLineageState<T>(
+  selector?: (state: LineageContextState) => T
+): LineageContextState | T {
+  const activeSelector = useShallow((store: LineageState): LineageContextState | T =>
+    selector ? selector(store) : selectLineageState(store)
+  );
 
-  return {
-    result,
-    sql,
-    selectedNodeId,
-    selectedStatementIndex,
-    highlightedSpan,
-    focusedOccurrenceIndex,
-    searchTerm,
-    viewMode,
-    matrixSubMode,
-    layoutAlgorithm,
-    layoutMetrics,
-    graphMetrics,
-    collapsedNodeIds,
-    expandedTableIds,
-    defaultCollapsed,
-    showColumnEdges,
-    hideCTEs,
-    showScriptTables,
-    navigationRequest,
-    visibleGraphNodeIds,
-    revealRequest,
-    tableFilter,
-    isLayouting,
-    isBuilding,
-    analyzedContentByPath,
-    stalePaths,
-  };
+  return useLineageStore<LineageContextState | T>(activeSelector);
 }
 
 /**
- * Hook to access only the lineage actions.
+ * Hook to access lineage actions. Action references and the no-argument action
+ * object remain stable for the lifetime of the store. A selector can narrow
+ * the returned API for components that use only a subset of actions.
  */
-export function useLineageActions() {
-  const setResult = useLineageStore((state) => state.setResult);
-  const setSql = useLineageStore((state) => state.setSql);
-  const selectNode = useLineageStore((state) => state.selectNode);
-  const cycleOccurrence = useLineageStore((state) => state.cycleOccurrence);
-  const focusOccurrence = useLineageStore((state) => state.focusOccurrence);
-  const toggleNodeCollapse = useLineageStore((state) => state.toggleNodeCollapse);
-  const setNodeCollapsed = useLineageStore((state) => state.setNodeCollapsed);
-  const toggleTableExpansion = useLineageStore((state) => state.toggleTableExpansion);
-  const setTableExpanded = useLineageStore((state) => state.setTableExpanded);
-  const setAllNodesCollapsed = useLineageStore((state) => state.setAllNodesCollapsed);
-  const selectStatement = useLineageStore((state) => state.selectStatement);
-  const highlightSpan = useLineageStore((state) => state.highlightSpan);
-  const setSearchTerm = useLineageStore((state) => state.setSearchTerm);
-  const setViewMode = useLineageStore((state) => state.setViewMode);
-  const setMatrixSubMode = useLineageStore((state) => state.setMatrixSubMode);
-  const setLayoutAlgorithm = useLineageStore((state) => state.setLayoutAlgorithm);
-  const setLayoutMetrics = useLineageStore((state) => state.setLayoutMetrics);
-  const setGraphMetrics = useLineageStore((state) => state.setGraphMetrics);
-  const toggleColumnEdges = useLineageStore((state) => state.toggleColumnEdges);
-  const toggleHideCTEs = useLineageStore((state) => state.toggleHideCTEs);
-  const toggleShowScriptTables = useLineageStore((state) => state.toggleShowScriptTables);
-  const requestNavigation = useLineageStore((state) => state.requestNavigation);
-  const setVisibleGraphNodeIds = useLineageStore((state) => state.setVisibleGraphNodeIds);
-  const revealNodeInGraph = useLineageStore((state) => state.revealNodeInGraph);
-  const clearRevealRequest = useLineageStore((state) => state.clearRevealRequest);
-  const setTableFilter = useLineageStore((state) => state.setTableFilter);
-  const toggleTableFilterSelection = useLineageStore((state) => state.toggleTableFilterSelection);
-  const setTableFilterDirection = useLineageStore((state) => state.setTableFilterDirection);
-  const clearTableFilter = useLineageStore((state) => state.clearTableFilter);
-  const setIsLayouting = useLineageStore((state) => state.setIsLayouting);
-  const setIsBuilding = useLineageStore((state) => state.setIsBuilding);
-  const setAnalyzedContent = useLineageStore((state) => state.setAnalyzedContent);
-  const setStalePaths = useLineageStore((state) => state.setStalePaths);
+export function useLineageActions(): LineageContextActions;
+export function useLineageActions<T>(selector: (actions: LineageContextActions) => T): T;
+export function useLineageActions<T>(
+  selector?: (actions: LineageContextActions) => T
+): LineageContextActions | T {
+  const activeSelector = useShallow((store: LineageState): LineageContextActions | T => {
+    const actions = selectLineageActions(store);
+    return selector ? selector(actions) : actions;
+  });
 
-  return {
-    setResult,
-    setSql,
-    selectNode,
-    cycleOccurrence,
-    focusOccurrence,
-    toggleNodeCollapse,
-    setNodeCollapsed,
-    toggleTableExpansion,
-    setTableExpanded,
-    setAllNodesCollapsed,
-    selectStatement,
-    highlightSpan,
-    setSearchTerm,
-    setViewMode,
-    setMatrixSubMode,
-    setLayoutAlgorithm,
-    setLayoutMetrics,
-    setGraphMetrics,
-    toggleColumnEdges,
-    toggleHideCTEs,
-    toggleShowScriptTables,
-    requestNavigation,
-    setVisibleGraphNodeIds,
-    revealNodeInGraph,
-    clearRevealRequest,
-    setTableFilter,
-    toggleTableFilterSelection,
-    setTableFilterDirection,
-    clearTableFilter,
-    setIsLayouting,
-    setIsBuilding,
-    setAnalyzedContent,
-    setStalePaths,
-  };
+  return useLineageStore<LineageContextActions | T>(activeSelector);
+}
+
+/**
+ * Hook to access the legacy structured state/actions value. Both nested
+ * objects are referentially stable until their selected store fields change.
+ */
+export function useLineage(): LineageContextValue {
+  const state = useLineageState();
+  const actions = useLineageActions();
+
+  return useMemo(() => ({ state, actions }), [state, actions]);
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -104,6 +104,8 @@ export interface LineageState {
   selectedStatementIndex: number;
   /** The currently highlighted span in the SQL editor, or null if none */
   highlightedSpan: Span | null;
+  /** Index of the selected node occurrence currently highlighted in the editor */
+  focusedOccurrenceIndex: number;
   /** Search term for filtering/highlighting nodes in the graph */
   searchTerm: string;
   /** Current view mode for the lineage graph */
@@ -141,6 +143,10 @@ export interface LineageState {
   revealRequest: { nodeId: string; nonce: number; suppressNavigation: boolean } | null;
   /** Table filter configuration */
   tableFilter: TableFilter;
+  /** Whether the graph layout is currently running */
+  isLayouting: boolean;
+  /** Whether the graph view model is currently being built */
+  isBuilding: boolean;
   /**
    * Snapshot of the SQL text each path held when the most recent analysis
    * ran, keyed by the analyzer's `sourceName`. `null` before any analysis
@@ -167,6 +173,10 @@ export interface LineageActions {
   setSql: (sql: string) => void;
   /** Select a node by ID, or null to deselect */
   selectNode: (nodeId: string | null) => void;
+  /** Cycle the highlighted occurrence of the selected node */
+  cycleOccurrence: (direction: 'next' | 'prev') => void;
+  /** Focus a specific occurrence of the selected node */
+  focusOccurrence: (index: number) => void;
   /** Toggle the collapsed state of a node */
   toggleNodeCollapse: (nodeId: string) => void;
   /** Explicitly set whether a node is collapsed */
@@ -223,6 +233,10 @@ export interface LineageActions {
   setTableFilterDirection: (direction: TableFilterDirection) => void;
   /** Clear the table filter */
   clearTableFilter: () => void;
+  /** Set whether the graph layout is currently running */
+  setIsLayouting: (isLayouting: boolean) => void;
+  /** Set whether the graph view model is currently being built */
+  setIsBuilding: (isBuilding: boolean) => void;
   /** Replace the analyzed-content snapshot (or clear with null). */
   setAnalyzedContent: (map: ReadonlyMap<string, string> | null) => void;
   /** Replace the set of paths whose content has diverged from the snapshot. */

--- a/packages/react/tests/storeHooks.test.tsx
+++ b/packages/react/tests/storeHooks.test.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from 'react';
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LineageExplorerInner } from '../src/components/LineageExplorer';
+import {
+  createLineageStore,
+  LineageStoreProvider,
+  useLineage,
+  useLineageActions,
+  useLineageState,
+} from '../src/store';
+import type { LineageActions, LineageContextValue } from '../src/types';
+
+vi.mock('../src/components/GraphView', () => ({ GraphView: () => null }));
+vi.mock('../src/components/SqlView', () => ({ SqlView: () => null }));
+vi.mock('../src/components/IssuesPanel', () => ({ IssuesPanel: () => null }));
+
+describe('lineage store hooks', () => {
+  it('rerenders a state selector only when its selected value changes', () => {
+    const store = createLineageStore();
+    let renderCount = 0;
+
+    function SelectedSql(): ReactNode {
+      renderCount += 1;
+      const { sql } = useLineageState((state) => ({
+        sql: state.sql,
+        selectedNodeId: state.selectedNodeId,
+      }));
+      return <span>{sql}</span>;
+    }
+
+    const view = render(
+      <LineageStoreProvider store={store}>
+        <SelectedSql />
+      </LineageStoreProvider>
+    );
+
+    expect(renderCount).toBe(1);
+
+    act(() => store.getState().setSearchTerm('unrelated'));
+    expect(renderCount).toBe(1);
+
+    act(() => store.getState().setSql('SELECT 1'));
+    expect(renderCount).toBe(2);
+    expect(view.getByText('SELECT 1')).toBeTruthy();
+  });
+
+  it('keeps aggregate action and legacy context references stable across parent rerenders', () => {
+    const store = createLineageStore();
+    const actionSnapshots: LineageActions[] = [];
+    const selectedActionSnapshots: Array<Pick<LineageActions, 'setResult' | 'setSql'>> = [];
+    const contextSnapshots: LineageContextValue[] = [];
+
+    function Consumer(): null {
+      actionSnapshots.push(useLineageActions());
+      selectedActionSnapshots.push(
+        useLineageActions((actions) => ({
+          setResult: actions.setResult,
+          setSql: actions.setSql,
+        }))
+      );
+      contextSnapshots.push(useLineage());
+      return null;
+    }
+
+    const view = render(
+      <LineageStoreProvider store={store}>
+        <Consumer />
+      </LineageStoreProvider>
+    );
+    view.rerender(
+      <LineageStoreProvider store={store}>
+        <Consumer />
+      </LineageStoreProvider>
+    );
+
+    expect(actionSnapshots).toHaveLength(2);
+    expect(actionSnapshots[1]).toBe(actionSnapshots[0]);
+    expect(selectedActionSnapshots).toHaveLength(2);
+    expect(selectedActionSnapshots[1]).toBe(selectedActionSnapshots[0]);
+    expect(contextSnapshots).toHaveLength(2);
+    expect(contextSnapshots[1]).toBe(contextSnapshots[0]);
+    expect(contextSnapshots[1].actions).toBe(contextSnapshots[0].actions);
+    expect(contextSnapshots[1].state).toBe(contextSnapshots[0].state);
+  });
+});
+
+describe('LineageExplorerInner store synchronization', () => {
+  it('runs synchronization effects only when their corresponding props change', () => {
+    const store = createLineageStore();
+    const originalSetResult = store.getState().setResult;
+    const originalSetSql = store.getState().setSql;
+    const setResult = vi.fn(originalSetResult);
+    const setSql = vi.fn(originalSetSql);
+    store.setState({ setResult, setSql });
+
+    const view = render(
+      <LineageStoreProvider store={store}>
+        <LineageExplorerInner result={null} sql="SELECT 1" />
+      </LineageStoreProvider>
+    );
+
+    expect(setResult).toHaveBeenCalledTimes(1);
+    expect(setSql).toHaveBeenCalledTimes(1);
+
+    act(() => store.getState().setSearchTerm('unrelated'));
+    view.rerender(
+      <LineageStoreProvider store={store}>
+        <LineageExplorerInner result={null} sql="SELECT 1" />
+      </LineageStoreProvider>
+    );
+
+    expect(setResult).toHaveBeenCalledTimes(1);
+    expect(setSql).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <LineageStoreProvider store={store}>
+        <LineageExplorerInner result={null} sql="SELECT 2" />
+      </LineageStoreProvider>
+    );
+
+    expect(setResult).toHaveBeenCalledTimes(1);
+    expect(setSql).toHaveBeenCalledTimes(2);
+    expect(setSql).toHaveBeenLastCalledWith('SELECT 2');
+  });
+});


### PR DESCRIPTION
## Summary

- add shallow-memoized selector overloads to `useLineageState` and `useLineageActions`
- preserve the documented no-argument hooks and structured `useLineage()` API with stable object references
- make `LineageExplorer` synchronize props through stable setter selectors
- remove the web app's action-ref workaround and depend on the stable actions contract
- add selector, reference-stability, and `LineageExplorer` effect regression coverage
- document the selector API and add an Unreleased changelog entry

## Root cause

`useLineage()` subscribed to the combined Zustand store and rebuilt both its `state` and `actions` objects on every store update. `LineageExplorerInner` used the reconstructed `actions` object as an effect dependency while those effects called `setResult` and `setSql`. Each setter update could therefore produce another action object, rerun the effects, and cause avoidable renders or an update loop. The state/action aggregate hooks also rebuilt return objects across parent renders and did not offer safe narrow subscriptions.

## Design

The aggregate state and action projections now have explicit selectors. `useLineageState` and `useLineageActions` accept optional typed selectors and shallow-memoize every selector result, including compound object selections. Their no-argument forms still return the full documented state or action object. `useLineage()` composes those stable projections and memoizes the legacy `{ state, actions }` shape.

`LineageExplorerInner` selects `setResult` and `setSql` directly, so its effects depend only on the matching prop and stable setter. `useAnalysis` now selects `hideCTEs`, consumes the stable action object directly, and lists it in effect/callback dependencies.

## Impact

Existing no-argument hook consumers keep the same API. New and migrated consumers can subscribe to only the fields they use, compound selectors are safe under React 19/Zustand 5, action and legacy context references remain stable across parent rerenders, and prop synchronization no longer repeats after unrelated store updates.

## Checks

- `yarn workspace @pondpilot/flowscope-react test` — 207 tests passed
- `yarn workspace @pondpilot/flowscope-react typecheck`
- `yarn workspace @pondpilot/flowscope-react lint`
- `yarn workspace @pondpilot/flowscope-react build`
- `eslint packages/react/tests/storeHooks.test.tsx`
- `yarn workspace @pondpilot/flowscope-app test` — 344 tests passed
- `yarn workspace @pondpilot/flowscope-app typecheck`
- `yarn workspace @pondpilot/flowscope-app lint`
- `codex review --uncommitted` — one P1 compound-selector finding accepted and fixed; repeat review completed with no actionable findings
